### PR TITLE
refactor: load telegram tokens from env

### DIFF
--- a/src/pss/tourism/telegram/Manager.java
+++ b/src/pss/tourism/telegram/Manager.java
@@ -24,9 +24,14 @@ import pss.tourism.interfaceGDS.log.BizInterfaceLog;
 import pss.tourism.pnr.BizPNRTicket;
 
 public class Manager {
-	public static final String TOKEN = "356653274:AAHb4WLaZRJJcp0RGPw-5a1lQmV0Yb-LwjM";
+        /**
+         * Telegram bot token. It should be provided via the environment variable
+         * {@code TELEGRAM_BOT_TOKEN} to avoid committing sensitive credentials to the
+         * repository.
+         */
+        public static final String TOKEN = System.getenv("TELEGRAM_BOT_TOKEN");
 
-	//
+        //
 	public static void main(String[] args) {
 		Manager.process(null);
 	}

--- a/src/pss/tourism/telegram/TelegramUserBot.java
+++ b/src/pss/tourism/telegram/TelegramUserBot.java
@@ -22,10 +22,14 @@ import pss.tourism.telegram.event.BizTelegramEvent;
 
 public class TelegramUserBot extends TelegramBotManager {
 
-	public static final int EVT_TICKET_ROBOT_OFFLINE = 3;
-	public static final int EVT_TICKET_NO_TICKETS = 4;
+        public static final int EVT_TICKET_ROBOT_OFFLINE = 3;
+        public static final int EVT_TICKET_NO_TICKETS = 4;
 
-	public static final String TOKEN = "7811283387:AAHCnq5DEf_akPpN1VYYhCIEGj-Dj5f3FFw";
+        /**
+         * Telegram bot token for user notifications. The value must be supplied via the
+         * {@code TELEGRAM_USER_BOT_TOKEN} environment variable.
+         */
+        public static final String TOKEN = System.getenv("TELEGRAM_USER_BOT_TOKEN");
 
 	public TelegramUserBot() throws Exception {
 	}


### PR DESCRIPTION
## Summary
- avoid committing bot credentials by loading tokens from TELEGRAM_BOT_TOKEN and TELEGRAM_USER_BOT_TOKEN environment variables

## Testing
- `javac src/pss/tourism/telegram/Manager.java` *(fails: package pss.bsp.bspBusiness does not exist)*
- `javac src/pss/tourism/telegram/TelegramUserBot.java` *(fails: package com.pengrad.telegrambot does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68996502908c8333a35e45764faff56f