### PR TITLE
Convert old contrato forms to responsive layout

### DIFF
--- a/src/pss/bsp/contrato/detalle/prorrateo/FormProrrateo.java
+++ b/src/pss/bsp/contrato/detalle/prorrateo/FormProrrateo.java
@@ -1,6 +1,11 @@
 package pss.bsp.contrato.detalle.prorrateo;
 
+import pss.bsp.dk.GuiClienteDKs;
+import pss.core.win.JControlWin;
+import pss.core.win.JWin;
+import pss.core.win.JWins;
 import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
 
 public class FormProrrateo extends JBaseForm {
 
@@ -19,5 +24,31 @@ private static final long serialVersionUID = 1446860278358L;
   }
 
   public GuiProrrateo getWin() { return (GuiProrrateo) getBaseWin(); }
+
+  /**
+   * Linkeo los campos con la variables del form
+   */
+  public void InicializarPanel( JWin zWin ) throws Exception {
+        AddItemEdit( null, CHAR, OPT, "id_prorrateo" ).setHide(true);
+        AddItemEdit( null, CHAR, OPT, "company" ).setHide(true);
+        AddItemEdit( null, CHAR, OPT, "contrato" ).setHide(true);
+        AddItemEdit( null, CHAR, OPT, "detalle" ).setHide(true);
+
+        JFormPanelResponsive row = AddItemRow();
+        row.AddItemWinLov( "Cliente", CHAR, REQ, "cliente", new JControlWin() {
+                @Override
+                public JWins getRecords(boolean bOneRow) throws Exception {
+                        return getClientes(bOneRow);
+                }
+        }).setSizeColumns(8);
+        row.AddItemEdit( "Comision", FLOAT, REQ, "valor" ).setSizeColumns(4);
+  }
+
+  public JWins getClientes(boolean one) throws Exception {
+        GuiClienteDKs wins = new GuiClienteDKs();
+        wins.getRecords().addFilter("company", getWin().GetcDato().getCompany());
+        wins.getRecords().addOrderBy("dk");
+        return wins;
+  }
 
 }  //  @jve:decl-index=0:visual-constraint="7,4"

--- a/src/pss/bsp/contrato/detalle/prorrateo/cliente/FormClienteProrrateo.java
+++ b/src/pss/bsp/contrato/detalle/prorrateo/cliente/FormClienteProrrateo.java
@@ -1,6 +1,9 @@
 package pss.bsp.contrato.detalle.prorrateo.cliente;
 
+import pss.core.win.JWin;
 import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
+import pss.core.winUI.responsiveControls.JFormTabPanelResponsive;
 
 public class FormClienteProrrateo extends JBaseForm {
 
@@ -19,5 +22,28 @@ private static final long serialVersionUID = 1446860278358L;
   }
 
   public GuiClienteProrrateo getWin() { return (GuiClienteProrrateo) getBaseWin(); }
+
+  /**
+   * Linkeo los campos con la variables del form
+   */
+  public void InicializarPanel( JWin zWin ) throws Exception {
+        AddItemEdit( null, CHAR, OPT, "company" ).setHide(true);
+        AddItemEdit( null, CHAR, OPT, "periodo" ).setHide(true);
+
+        JFormPanelResponsive row = AddItemRow();
+        row.AddItemEdit( "Cliente", CHAR, REQ, "cliente" ).setSizeColumns(6);
+        row.AddItemEdit( "Descripción", CHAR, OPT, "descripcion" ).setSizeColumns(6);
+
+        row = AddItemRow();
+        row.AddItemEdit( "Número", CHAR, OPT, "numero" ).setSizeColumns(4);
+        row.AddItemEdit( "Moneda", CHAR, OPT, "moneda" ).setSizeColumns(4);
+        row.AddItemEdit( "Tarifa", FLOAT, OPT, "monto" ).setSizeColumns(4);
+
+        row = AddItemRow();
+        row.AddItemEdit( "Comisión", FLOAT, OPT, "comision" ).setSizeColumns(4);
+
+        JFormTabPanelResponsive tabs = AddItemTabPanel();
+        tabs.AddItemList(120);
+  }
 
 }  //  @jve:decl-index=0:visual-constraint="7,4"

--- a/src/pss/bsp/contrato/detalle/prorrateo/header/FormHeaderProrrateo.java
+++ b/src/pss/bsp/contrato/detalle/prorrateo/header/FormHeaderProrrateo.java
@@ -1,6 +1,8 @@
 package pss.bsp.contrato.detalle.prorrateo.header;
 
+import pss.core.win.JWin;
 import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormTabPanelResponsive;
 
 public class FormHeaderProrrateo extends JBaseForm {
 
@@ -19,5 +21,16 @@ private static final long serialVersionUID = 1446860278358L;
   }
 
   public GuiHeaderProrrateo getWin() { return (GuiHeaderProrrateo) getBaseWin(); }
+
+  /**
+   * Linkeo los campos con la variables del form
+   */
+  public void InicializarPanel( JWin zWin ) throws Exception {
+        AddItemEdit( null, CHAR, OPT, "company" ).setHide(true);
+        AddItemEdit( null, CHAR, OPT, "periodo" ).setHide(true);
+
+        JFormTabPanelResponsive tabs = AddItemTabPanel();
+        tabs.AddItemList(120);
+  }
 
 }  //  @jve:decl-index=0:visual-constraint="7,4"

--- a/src/pss/bsp/contrato/detalle/prorrateo/tickets/FormTicketProrrateo.java
+++ b/src/pss/bsp/contrato/detalle/prorrateo/tickets/FormTicketProrrateo.java
@@ -1,19 +1,50 @@
 package pss.bsp.contrato.detalle.prorrateo.tickets;
 
-import java.awt.Dimension;
-import java.awt.Rectangle;
-import pss.core.winUI.forms.JBaseForm;
-import pss.core.ui.components.*;
+import pss.core.win.JControlWin;
 import pss.core.win.JWin;
-import pss.core.ui.components.JPssLabel;
+import pss.core.win.JWins;
+import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
+import pss.tourism.pnr.GuiPNRTickets;
 
 public class FormTicketProrrateo extends JBaseForm {
 
-
 private static final long serialVersionUID = 1446860154249L;
 
- 
+  public FormTicketProrrateo() throws Exception {}
 
   public GuiTicketProrrateo getWin() { return (GuiTicketProrrateo) getBaseWin(); }
 
+  /**
+   * Linkeo los campos con la variables del form
+   */
+  public void InicializarPanel( JWin zWin ) throws Exception {
+        AddItemEdit( null, CHAR, OPT, "company" ).setHide(true);
+        AddItemEdit( null, CHAR, OPT, "id" ).setHide(true);
+        AddItemEdit( null, CHAR, OPT, "linea" ).setHide(true);
+        AddItemEdit( null, CHAR, OPT, "id_contrato" ).setHide(true);
+
+        JFormPanelResponsive row = AddItemRow();
+        row.AddItemWinLov( "Ticket", CHAR, REQ, "ticket", new JControlWin() {
+                @Override
+                public JWins getRecords(boolean bOneRow) throws Exception {
+                        return getTicket(bOneRow);
+                }
+        }).setSizeColumns(6);
+        row.AddItemEdit( "Cliente", CHAR, OPT, "customer" ).setSizeColumns(6);
+
+        row = AddItemRow();
+        row.AddItemEdit( "Porcentaje", FLOAT, OPT, "porcentaje" ).setSizeColumns(4);
+        row.AddItemEdit( "Comisión", FLOAT, OPT, "comision" ).setSizeColumns(4);
+        row.AddItemDateTime( "Fecha", DATE, OPT, "fecha" ).setSizeColumns(4);
+  }
+
+  public JWins getTicket(boolean one) throws Exception {
+        GuiPNRTickets wins = new GuiPNRTickets();
+        if (one) {
+                wins.getRecords().addFilter("id", getWin().GetcDato().getObjTicket().getId());
+        }
+        return wins;
+  }
 }
+

--- a/src/pss/bsp/contrato/total/FormTotal.java
+++ b/src/pss/bsp/contrato/total/FormTotal.java
@@ -1,6 +1,8 @@
 package pss.bsp.contrato.total;
 
+import pss.core.win.JWin;
 import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
 
 public class FormTotal extends JBaseForm {
 
@@ -16,5 +18,19 @@ private static final long serialVersionUID = 1446860154249L;
 
   public GuiTotal getWin() { return (GuiTotal) getBaseWin(); }
 
-  
-} 
+  /**
+   * Linkeo los campos con la variables del form
+   */
+  public void InicializarPanel( JWin zWin ) throws Exception {
+        AddItemEdit( null, CHAR, OPT, "id" ).setHide(true);
+
+        JFormPanelResponsive row = AddItemRow();
+        row.AddItemEdit( "Grupo", CHAR, OPT, "grupo" ).setReadOnly(true).setSizeColumns(6);
+        row.AddItemEdit( "Moneda", CHAR, OPT, "moneda" ).setReadOnly(true).setSizeColumns(6);
+
+        row = AddItemRow();
+        row.AddItemEdit( "Base Comisionable", FLOAT, OPT, "base_comisionable" ).setReadOnly(true).setSizeColumns(6);
+        row.AddItemEdit( "Ganancia", FLOAT, OPT, "ganancia" ).setReadOnly(true).setSizeColumns(6);
+  }
+
+}


### PR DESCRIPTION
## Summary
- Modernize FormProrrateo with responsive rows, client lookup, and commission field
- Implement responsive layout for FormClienteProrrateo including customer details and ticket list
- Add initialization for FormHeaderProrrateo, FormTicketProrrateo, and FormTotal with responsive controls

## Testing
- `javac -cp src src/pss/bsp/contrato/detalle/prorrateo/FormProrrateo.java` *(fails: unmappable character for encoding UTF-8)*

------
https://chatgpt.com/codex/tasks/task_e_689a3a03d7c48333af900eb0e1d8ff75