### PR TITLE
Refactorizar forms PDF a estilo FormBooking

### DIFF
--- a/src/pss/bsp/pdf/FormNewPDF.java
+++ b/src/pss/bsp/pdf/FormNewPDF.java
@@ -1,81 +1,34 @@
 package  pss.bsp.pdf;
 
-import java.awt.Dimension;
-import java.awt.Rectangle;
-
-import pss.core.ui.components.JPssEdit;
-import pss.core.ui.components.JPssLabel;
-import pss.core.ui.components.JPssLabelFile;
 import pss.core.win.JWin;
 import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
 
 public class FormNewPDF extends JBaseForm {
 
 
 private static final long serialVersionUID = 1245253394589L;
 
-  JPssEdit company = new JPssEdit  ();
-JPssEdit owner = new JPssEdit  ();
-JPssEdit idPDF = new JPssEdit  ();
-JPssLabel ldescripcion = new JPssLabel();
-JPssEdit descripcion = new JPssEdit  ();
-JPssLabel lpdfFilename = new JPssLabel();
-JPssLabelFile pdfFilename = new JPssLabelFile  ();
-
-
   /**
    * Constructor de la Clase
    */
   public FormNewPDF() throws Exception {
-    try { jbInit(); }
-    catch (Exception e) { e.printStackTrace(); } 
   }
- 
+
   public GuiPDF getWin() { return (GuiPDF) getBaseWin(); }
 
-  /**
-   * Inicializacion Grafica
-   */
-  protected void jbInit() throws Exception {
-    setLayout(null);
-    setSize(new Dimension(512, 117));
-
-
-    company.setBounds(new Rectangle(3, 8, 14, 22)); 
-    add(company , null);
-
-
-    owner.setBounds(new Rectangle(3, 35, 14, 22)); 
-    add(owner , null);
-
-
-    idPDF.setBounds(new Rectangle(3, 62, 14, 22)); 
-    add(idPDF , null);
-
-
-    ldescripcion.setText( "Descripcion" );
-    ldescripcion.setBounds(new Rectangle(29, 28, 123, 22)); 
-    descripcion.setBounds(new Rectangle(157, 28, 336, 22)); 
-    add(ldescripcion, null);
-    add(descripcion , null);
-
-
-    lpdfFilename.setText( "Archivo PDF o ZIP:" );
-    lpdfFilename.setBounds(new Rectangle(29, 54, 123, 22)); 
-    pdfFilename.setBounds(new Rectangle(157, 54, 337, 22)); 
-    add(lpdfFilename, null);
-    add(pdfFilename , null);
-    
-  }
   /**
    * Linkeo los campos con la variables del form
    */
   public void InicializarPanel( JWin zWin ) throws Exception {
-    AddItem( company, CHAR, OPT, "company" ).setVisible(false);
-    AddItem( owner, CHAR, OPT, "owner" ).setVisible(false);
-    AddItem( idPDF, CHAR, OPT, "idPDF" ).setVisible(false);
-    AddItem( descripcion, CHAR, OPT, "descripcion" );
-    AddItem( pdfFilename, CHAR, OPT, "pdffilename" );
+    AddItemEdit( null, CHAR, OPT, "company" ).setHide(true);
+    AddItemEdit( null, CHAR, OPT, "owner" ).setHide(true);
+    AddItemEdit( null, CHAR, OPT, "idPDF" ).setHide(true);
 
-  } 
-}  //  @jve:decl-index=0:visual-constraint="10,10" 
+    JFormPanelResponsive row = AddItemRow();
+    row.AddItemEdit( "Descripcion", CHAR, OPT, "descripcion" ).setSizeColumns(12);
+
+    row = AddItemRow();
+    row.AddItemFile( "Archivo PDF o ZIP:", CHAR, OPT, "pdffilename" ).setSizeColumns(12);
+  }
+}

--- a/src/pss/bsp/pdf/FormPDF.java
+++ b/src/pss/bsp/pdf/FormPDF.java
@@ -1,126 +1,44 @@
 package  pss.bsp.pdf;
 
-import java.awt.Dimension;
-import java.awt.Rectangle;
-
-import javax.swing.JTabbedPane;
-
-import pss.core.ui.components.JPssEdit;
-import pss.core.ui.components.JPssLabel;
 import pss.core.win.JWin;
 import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
+import pss.core.winUI.responsiveControls.JFormTabPanelResponsive;
 
 public class FormPDF extends JBaseForm {
 
 
 private static final long serialVersionUID = 1245253394589L;
 
-  JPssEdit company = new JPssEdit  ();
-JPssEdit owner = new JPssEdit  ();
-JPssLabel lidPDF = new JPssLabel();
-JPssEdit idPDF = new JPssEdit  ();
-JPssLabel ldescripcion = new JPssLabel();
-JPssEdit descripcion = new JPssEdit  ();
-JPssLabel lestado = new JPssLabel();
-JPssEdit estado = new JPssEdit  ();
-JPssLabel lfecha_desde = new JPssLabel();
-JPssEdit fecha_desde = new JPssEdit  ();
-JPssLabel lfecha_hasta = new JPssLabel();
-JPssEdit fecha_hasta = new JPssEdit  ();
-
-private JTabbedPane jTabbedPane = null;
-
-
   /**
    * Constructor de la Clase
    */
   public FormPDF() throws Exception {
-    try { jbInit(); }
-    catch (Exception e) { e.printStackTrace(); } 
   }
 
   public GuiPDF getWin() { return (GuiPDF) getBaseWin(); }
 
   /**
-   * Inicializacion Grafica
-   */
-  protected void jbInit() throws Exception {
-    setLayout(null);
-    setSize(new Dimension(583, 515));
-
-
-    company.setBounds(new Rectangle(3, 29, 14, 22)); 
-    add(company , null);
-
-
-    owner.setBounds(new Rectangle(2, 2, 16, 22)); 
-    add(owner , null);
-
-
-    lidPDF.setText("Id.Liquidacion");
-    lidPDF.setBounds(new Rectangle(29, 15, 123, 22)); 
-    idPDF.setBounds(new Rectangle(157, 15, 143, 22)); 
-    add(lidPDF, null);
-    add(idPDF , null);
-
-
-    ldescripcion.setText( "Descripcion" );
-    ldescripcion.setBounds(new Rectangle(29, 41, 123, 22)); 
-    descripcion.setBounds(new Rectangle(157, 41, 418, 22)); 
-    add(ldescripcion, null);
-    add(descripcion , null);
-
-
-    lestado.setText( "Estado" );
-    lestado.setBounds(new Rectangle(304, 15, 123, 22)); 
-    estado.setBounds(new Rectangle(432, 15, 143, 22)); 
-    add(lestado, null);
-    add(estado , null);
-
-
-    lfecha_desde.setText( "Fecha desde" );
-    lfecha_desde.setBounds(new Rectangle(29, 68, 123, 22)); 
-    fecha_desde.setBounds(new Rectangle(157, 68, 143, 22)); 
-    add(lfecha_desde, null);
-    add(fecha_desde , null);
-
-
-    lfecha_hasta.setText( "Fecha hasta" );
-    lfecha_hasta.setBounds(new Rectangle(304, 68, 123, 22)); 
-    fecha_hasta.setBounds(new Rectangle(432, 68, 143, 22)); 
-    add(lfecha_hasta, null);
-    add(fecha_hasta , null);
-
-    this.add(getJTabbedPane(), null);
-    
-  }
-  /**
    * Linkeo los campos con la variables del form
    */
   public void InicializarPanel( JWin zWin ) throws Exception {
-    AddItem( company, CHAR, REQ, "company" ).setVisible(false);
-    AddItem( owner, CHAR, REQ, "owner" ).setVisible(false);;
-    AddItem( idPDF, CHAR, REQ, "idPDF" );
-    AddItem( descripcion, CHAR, REQ, "descripcion" );
-    AddItem( estado, CHAR, REQ, "estado" );
-    AddItem( fecha_desde, UINT, REQ, "fecha_desde" );
-    AddItem( fecha_hasta, UINT, REQ, "fecha_hasta" );
-    AddItem( getJTabbedPane(),20);
-    AddItem( getJTabbedPane(),25);
-    AddItemForm( getJTabbedPane(),10);
- 
-  }
+    AddItemEdit( null, CHAR, REQ, "company" ).setHide(true);
+    AddItemEdit( null, CHAR, REQ, "owner" ).setHide(true);
 
-  /**
-   * This method initializes jTabbedPane	
-   * 	
-   * @return javax.swing.JTabbedPane	
-   */
-  private JTabbedPane getJTabbedPane() {
-  	if (jTabbedPane==null) {
-  		jTabbedPane=new JTabbedPane();
-  		jTabbedPane.setBounds(new Rectangle(26, 103, 547, 399));
-  	}
-  	return jTabbedPane;
-  } 
-}  //  @jve:decl-index=0:visual-constraint="10,10" 
+    JFormPanelResponsive row = AddItemRow();
+    row.AddItemEdit( "Id.Liquidacion", CHAR, REQ, "idPDF" ).setSizeColumns(6);
+    row.AddItemEdit( "Estado", CHAR, REQ, "estado" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Descripcion", CHAR, REQ, "descripcion" ).setSizeColumns(12);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Fecha desde", UINT, REQ, "fecha_desde" ).setSizeColumns(6);
+    row.AddItemEdit( "Fecha hasta", UINT, REQ, "fecha_hasta" ).setSizeColumns(6);
+
+    JFormTabPanelResponsive tabs = AddItemTabPanel();
+    tabs.AddItemList(20);
+    tabs.AddItemList(25);
+    tabs.AddItemList(10);
+  }
+}


### PR DESCRIPTION
## Resumen
- Migrados `FormPDF` y `FormNewPDF` a los controles responsivos siguiendo el patrón de `FormBooking`.
- Simplificación de código eliminando layouts absolutos y uso directo de `AddItem*`.
- Ajustado `FormPDF` para construir un panel de pestañas responsivo con listas 20, 25 y 10.

## Testing
- `javac -encoding ISO-8859-1 -cp src -d /tmp/classes src/pss/bsp/pdf/FormPDF.java src/pss/bsp/pdf/FormNewPDF.java` *(errores de caracteres no mapeados en archivos dependientes)*

------
https://chatgpt.com/codex/tasks/task_e_689a4df6445c83338ff8fd388eb83e47