### PR TITLE
refactor: migrate cabecera forms to responsive model

### DIFF
--- a/src/pss/bsp/pdf/arg/cabecera/FormArgCabecera.java
+++ b/src/pss/bsp/pdf/arg/cabecera/FormArgCabecera.java
@@ -1,131 +1,40 @@
-package  pss.bsp.pdf.arg.cabecera;
+package pss.bsp.pdf.arg.cabecera;
 
-import java.awt.Dimension;
-import java.awt.Rectangle;
-import pss.core.winUI.forms.JBaseForm;
-import pss.core.ui.components.*;
 import pss.core.win.JWin;
+import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
 
 public class FormArgCabecera extends JBaseForm {
 
+  private static final long serialVersionUID = 1245253623694L;
 
-private static final long serialVersionUID = 1245253623694L;
-
-  JPssEdit company = new JPssEdit  ();
-JPssEdit owner = new JPssEdit  ();
-JPssLabel lidPDF = new JPssLabel();
-JPssEdit idPDF = new JPssEdit  ();
-JPssLabel ldescripcion = new JPssLabel();
-JPssEdit descripcion = new JPssEdit  ();
-JPssLabel ldireccion = new JPssLabel();
-JPssEdit direccion = new JPssEdit  ();
-JPssLabel lcodigo_postal = new JPssLabel();
-JPssEdit codigo_postal = new JPssEdit  ();
-JPssLabel lIATA = new JPssLabel();
-JPssEdit IATA = new JPssEdit  ();
-JPssLabel lCIF = new JPssLabel();
-JPssEdit CIF = new JPssEdit  ();
-JPssLabel llocalidad = new JPssLabel();
-JPssEdit localidad = new JPssEdit  ();
-JPssLabel lmoneda = new JPssLabel();
-JPssEdit moneda = new JPssEdit  ();
-
-
-  /**
-   * Constructor de la Clase
-   */
-  public FormArgCabecera() throws Exception {
-    try { jbInit(); }
-    catch (Exception e) { e.printStackTrace(); } 
-  }
+  public FormArgCabecera() throws Exception {}
 
   public GuiArgCabecera getWin() { return (GuiArgCabecera) getBaseWin(); }
 
   /**
-   * Inicializacion Grafica
-   */
-  protected void jbInit() throws Exception {
-    setLayout(null);
-    setSize(new Dimension(549, 150));
-
-
-    company.setBounds(new Rectangle(2, 5, 16, 22)); 
-    add(company , null);
-
-
-    owner.setBounds(new Rectangle(2, 31, 20, 22)); 
-    add(owner , null);
-
-
-    lidPDF.setText("ID Liquidacion");
-    lidPDF.setBounds(new Rectangle(30-20, 5, 123, 22)); 
-    idPDF.setBounds(new Rectangle(158-20, 5, 143, 22)); 
-    add(lidPDF, null);
-    add(idPDF , null);
-
-
-    ldescripcion.setText( "Descripcion" );
-    ldescripcion.setBounds(new Rectangle(30-20, 29, 123, 22)); 
-    descripcion.setBounds(new Rectangle(158-20, 29, 387, 22)); 
-    add(ldescripcion, null);
-    add(descripcion , null);
-
-
-    ldireccion.setText( "Direccion" );
-    ldireccion.setBounds(new Rectangle(30-20, 54, 123, 22)); 
-    direccion.setBounds(new Rectangle(158-20, 54, 143, 22)); 
-    add(ldireccion, null);
-    add(direccion , null);
-
-
-    lcodigo_postal.setText( "Codigo postal" );
-    lcodigo_postal.setBounds(new Rectangle(303-20, 54, 98, 22)); 
-    codigo_postal.setBounds(new Rectangle(403-20, 54, 143, 22)); 
-    add(lcodigo_postal, null);
-    add(codigo_postal , null);
-
-
-    lIATA.setText("IATA");
-    lIATA.setBounds(new Rectangle(303-20, 5, 98, 22)); 
-    IATA.setBounds(new Rectangle(403-20, 5, 143, 22)); 
-    add(lIATA, null);
-    add(IATA , null);
-
-
-    lCIF.setText("Clave Fiscal");
-    lCIF.setBounds(new Rectangle(303-20, 80, 98, 22)); 
-    CIF.setBounds(new Rectangle(403-20, 80, 143, 22)); 
-    add(lCIF, null);
-    add(CIF , null);
-
-
-    llocalidad.setText( "Localidad" );
-    llocalidad.setBounds(new Rectangle(30-20, 80, 123, 22)); 
-    localidad.setBounds(new Rectangle(158-20, 80, 143, 22)); 
-    add(llocalidad, null);
-    add(localidad , null);
-
-
-    lmoneda.setText( "Moneda" );
-    lmoneda.setBounds(new Rectangle(30-20, 106, 123, 22)); 
-    moneda.setBounds(new Rectangle(158-20, 106, 143, 22)); 
-    add(lmoneda, null);
-    add(moneda , null);
-  }
-  /**
    * Linkeo los campos con la variables del form
    */
   public void InicializarPanel( JWin zWin ) throws Exception {
-    AddItem( company, CHAR, REQ, "company" ).setVisible(false);
-    AddItem( owner, CHAR, REQ, "owner" ).setVisible(false);
-    AddItem( idPDF, CHAR, REQ, "idPDF" );
-    AddItem( descripcion, CHAR, REQ, "descripcion" );
-    AddItem( direccion, CHAR, REQ, "direccion" );
-    AddItem( codigo_postal, CHAR, REQ, "codigo_postal" );
-    AddItem( IATA, CHAR, REQ, "IATA" );
-    AddItem( CIF, CHAR, REQ, "CIF" );
-    AddItem( localidad, CHAR, REQ, "localidad" );
-    AddItem( moneda, CHAR, REQ, "moneda" );
+    AddItemEdit( null, CHAR, REQ, "company" ).setHide(true);
+    AddItemEdit( null, CHAR, REQ, "owner" ).setHide(true);
 
-  } 
-}  //  @jve:decl-index=0:visual-constraint="10,10" 
+    JFormPanelResponsive row = AddItemRow();
+    row.AddItemEdit( "ID Liquidacion", CHAR, REQ, "idPDF" ).setSizeColumns(6);
+    row.AddItemEdit( "IATA", CHAR, REQ, "IATA" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Descripcion", CHAR, REQ, "descripcion" ).setSizeColumns(12);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Direccion", CHAR, REQ, "direccion" ).setSizeColumns(6);
+    row.AddItemEdit( "Codigo postal", CHAR, REQ, "codigo_postal" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Localidad", CHAR, REQ, "localidad" ).setSizeColumns(6);
+    row.AddItemEdit( "Clave Fiscal", CHAR, REQ, "CIF" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Moneda", CHAR, REQ, "moneda" ).setSizeColumns(6);
+  }
+}

--- a/src/pss/bsp/pdf/bol/cabecera/FormBolCabecera.java
+++ b/src/pss/bsp/pdf/bol/cabecera/FormBolCabecera.java
@@ -1,131 +1,40 @@
-package  pss.bsp.pdf.bol.cabecera;
+package pss.bsp.pdf.bol.cabecera;
 
-import java.awt.Dimension;
-import java.awt.Rectangle;
-import pss.core.winUI.forms.JBaseForm;
-import pss.core.ui.components.*;
 import pss.core.win.JWin;
+import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
 
 public class FormBolCabecera extends JBaseForm {
 
+  private static final long serialVersionUID = 1245253623694L;
 
-private static final long serialVersionUID = 1245253623694L;
-
-  JPssEdit company = new JPssEdit  ();
-JPssEdit owner = new JPssEdit  ();
-JPssLabel lidPDF = new JPssLabel();
-JPssEdit idPDF = new JPssEdit  ();
-JPssLabel ldescripcion = new JPssLabel();
-JPssEdit descripcion = new JPssEdit  ();
-JPssLabel ldireccion = new JPssLabel();
-JPssEdit direccion = new JPssEdit  ();
-JPssLabel lcodigo_postal = new JPssLabel();
-JPssEdit codigo_postal = new JPssEdit  ();
-JPssLabel lIATA = new JPssLabel();
-JPssEdit IATA = new JPssEdit  ();
-JPssLabel lCIF = new JPssLabel();
-JPssEdit CIF = new JPssEdit  ();
-JPssLabel llocalidad = new JPssLabel();
-JPssEdit localidad = new JPssEdit  ();
-JPssLabel lmoneda = new JPssLabel();
-JPssEdit moneda = new JPssEdit  ();
-
-
-  /**
-   * Constructor de la Clase
-   */
-  public FormBolCabecera() throws Exception {
-    try { jbInit(); }
-    catch (Exception e) { e.printStackTrace(); } 
-  }
+  public FormBolCabecera() throws Exception {}
 
   public GuiBolCabecera getWin() { return (GuiBolCabecera) getBaseWin(); }
 
   /**
-   * Inicializacion Grafica
-   */
-  protected void jbInit() throws Exception {
-    setLayout(null);
-    setSize(new Dimension(549, 150));
-
-
-    company.setBounds(new Rectangle(2, 5, 16, 22)); 
-    add(company , null);
-
-
-    owner.setBounds(new Rectangle(2, 31, 20, 22)); 
-    add(owner , null);
-
-
-    lidPDF.setText("ID Liquidacion");
-    lidPDF.setBounds(new Rectangle(30-20, 5, 123, 22)); 
-    idPDF.setBounds(new Rectangle(158-20, 5, 143, 22)); 
-    add(lidPDF, null);
-    add(idPDF , null);
-
-
-    ldescripcion.setText( "Descripcion" );
-    ldescripcion.setBounds(new Rectangle(30-20, 29, 123, 22)); 
-    descripcion.setBounds(new Rectangle(158-20, 29, 387, 22)); 
-    add(ldescripcion, null);
-    add(descripcion , null);
-
-
-    ldireccion.setText( "Direccion" );
-    ldireccion.setBounds(new Rectangle(30-20, 54, 123, 22)); 
-    direccion.setBounds(new Rectangle(158-20, 54, 143, 22)); 
-    add(ldireccion, null);
-    add(direccion , null);
-
-
-    lcodigo_postal.setText( "Codigo postal" );
-    lcodigo_postal.setBounds(new Rectangle(303-20, 54, 98, 22)); 
-    codigo_postal.setBounds(new Rectangle(403-20, 54, 143, 22)); 
-    add(lcodigo_postal, null);
-    add(codigo_postal , null);
-
-
-    lIATA.setText("IATA");
-    lIATA.setBounds(new Rectangle(303-20, 5, 98, 22)); 
-    IATA.setBounds(new Rectangle(403-20, 5, 143, 22)); 
-    add(lIATA, null);
-    add(IATA , null);
-
-
-    lCIF.setText("Clave Fiscal");
-    lCIF.setBounds(new Rectangle(303-20, 80, 98, 22)); 
-    CIF.setBounds(new Rectangle(403-20, 80, 143, 22)); 
-    add(lCIF, null);
-    add(CIF , null);
-
-
-    llocalidad.setText( "Localidad" );
-    llocalidad.setBounds(new Rectangle(30-20, 80, 123, 22)); 
-    localidad.setBounds(new Rectangle(158-20, 80, 143, 22)); 
-    add(llocalidad, null);
-    add(localidad , null);
-
-
-    lmoneda.setText( "Moneda" );
-    lmoneda.setBounds(new Rectangle(30-20, 106, 123, 22)); 
-    moneda.setBounds(new Rectangle(158-20, 106, 143, 22)); 
-    add(lmoneda, null);
-    add(moneda , null);
-  }
-  /**
    * Linkeo los campos con la variables del form
    */
   public void InicializarPanel( JWin zWin ) throws Exception {
-    AddItem( company, CHAR, REQ, "company" ).setVisible(false);
-    AddItem( owner, CHAR, REQ, "owner" ).setVisible(false);
-    AddItem( idPDF, CHAR, REQ, "idPDF" );
-    AddItem( descripcion, CHAR, REQ, "descripcion" );
-    AddItem( direccion, CHAR, REQ, "direccion" );
-    AddItem( codigo_postal, CHAR, REQ, "codigo_postal" );
-    AddItem( IATA, CHAR, REQ, "IATA" );
-    AddItem( CIF, CHAR, REQ, "CIF" );
-    AddItem( localidad, CHAR, REQ, "localidad" );
-    AddItem( moneda, CHAR, REQ, "moneda" );
+    AddItemEdit( null, CHAR, REQ, "company" ).setHide(true);
+    AddItemEdit( null, CHAR, REQ, "owner" ).setHide(true);
 
-  } 
-}  //  @jve:decl-index=0:visual-constraint="10,10" 
+    JFormPanelResponsive row = AddItemRow();
+    row.AddItemEdit( "ID Liquidacion", CHAR, REQ, "idPDF" ).setSizeColumns(6);
+    row.AddItemEdit( "IATA", CHAR, REQ, "IATA" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Descripcion", CHAR, REQ, "descripcion" ).setSizeColumns(12);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Direccion", CHAR, REQ, "direccion" ).setSizeColumns(6);
+    row.AddItemEdit( "Codigo postal", CHAR, REQ, "codigo_postal" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Localidad", CHAR, REQ, "localidad" ).setSizeColumns(6);
+    row.AddItemEdit( "Clave Fiscal", CHAR, REQ, "CIF" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Moneda", CHAR, REQ, "moneda" ).setSizeColumns(6);
+  }
+}

--- a/src/pss/bsp/pdf/chl/cabecera/FormChileCabecera.java
+++ b/src/pss/bsp/pdf/chl/cabecera/FormChileCabecera.java
@@ -1,131 +1,40 @@
-package  pss.bsp.pdf.chl.cabecera;
+package pss.bsp.pdf.chl.cabecera;
 
-import java.awt.Dimension;
-import java.awt.Rectangle;
-import pss.core.winUI.forms.JBaseForm;
-import pss.core.ui.components.*;
 import pss.core.win.JWin;
+import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
 
 public class FormChileCabecera extends JBaseForm {
 
+  private static final long serialVersionUID = 1245253623694L;
 
-private static final long serialVersionUID = 1245253623694L;
-
-  JPssEdit company = new JPssEdit  ();
-JPssEdit owner = new JPssEdit  ();
-JPssLabel lidPDF = new JPssLabel();
-JPssEdit idPDF = new JPssEdit  ();
-JPssLabel ldescripcion = new JPssLabel();
-JPssEdit descripcion = new JPssEdit  ();
-JPssLabel ldireccion = new JPssLabel();
-JPssEdit direccion = new JPssEdit  ();
-JPssLabel lcodigo_postal = new JPssLabel();
-JPssEdit codigo_postal = new JPssEdit  ();
-JPssLabel lIATA = new JPssLabel();
-JPssEdit IATA = new JPssEdit  ();
-JPssLabel lCIF = new JPssLabel();
-JPssEdit CIF = new JPssEdit  ();
-JPssLabel llocalidad = new JPssLabel();
-JPssEdit localidad = new JPssEdit  ();
-JPssLabel lmoneda = new JPssLabel();
-JPssEdit moneda = new JPssEdit  ();
-
-
-  /**
-   * Constructor de la Clase
-   */
-  public FormChileCabecera() throws Exception {
-    try { jbInit(); }
-    catch (Exception e) { e.printStackTrace(); } 
-  }
+  public FormChileCabecera() throws Exception {}
 
   public GuiChileCabecera getWin() { return (GuiChileCabecera) getBaseWin(); }
 
   /**
-   * Inicializacion Grafica
-   */
-  protected void jbInit() throws Exception {
-    setLayout(null);
-    setSize(new Dimension(549, 150));
-
-
-    company.setBounds(new Rectangle(2, 5, 16, 22)); 
-    add(company , null);
-
-
-    owner.setBounds(new Rectangle(2, 31, 20, 22)); 
-    add(owner , null);
-
-
-    lidPDF.setText("ID Liquidacion");
-    lidPDF.setBounds(new Rectangle(30-20, 5, 123, 22)); 
-    idPDF.setBounds(new Rectangle(158-20, 5, 143, 22)); 
-    add(lidPDF, null);
-    add(idPDF , null);
-
-
-    ldescripcion.setText( "Descripcion" );
-    ldescripcion.setBounds(new Rectangle(30-20, 29, 123, 22)); 
-    descripcion.setBounds(new Rectangle(158-20, 29, 387, 22)); 
-    add(ldescripcion, null);
-    add(descripcion , null);
-
-
-    ldireccion.setText( "Direccion" );
-    ldireccion.setBounds(new Rectangle(30-20, 54, 123, 22)); 
-    direccion.setBounds(new Rectangle(158-20, 54, 143, 22)); 
-    add(ldireccion, null);
-    add(direccion , null);
-
-
-    lcodigo_postal.setText( "Codigo postal" );
-    lcodigo_postal.setBounds(new Rectangle(303-20, 54, 98, 22)); 
-    codigo_postal.setBounds(new Rectangle(403-20, 54, 143, 22)); 
-    add(lcodigo_postal, null);
-    add(codigo_postal , null);
-
-
-    lIATA.setText("IATA");
-    lIATA.setBounds(new Rectangle(303-20, 5, 98, 22)); 
-    IATA.setBounds(new Rectangle(403-20, 5, 143, 22)); 
-    add(lIATA, null);
-    add(IATA , null);
-
-
-    lCIF.setText("Clave Fiscal");
-    lCIF.setBounds(new Rectangle(303-20, 80, 98, 22)); 
-    CIF.setBounds(new Rectangle(403-20, 80, 143, 22)); 
-    add(lCIF, null);
-    add(CIF , null);
-
-
-    llocalidad.setText( "Localidad" );
-    llocalidad.setBounds(new Rectangle(30-20, 80, 123, 22)); 
-    localidad.setBounds(new Rectangle(158-20, 80, 143, 22)); 
-    add(llocalidad, null);
-    add(localidad , null);
-
-
-    lmoneda.setText( "Moneda" );
-    lmoneda.setBounds(new Rectangle(30-20, 106, 123, 22)); 
-    moneda.setBounds(new Rectangle(158-20, 106, 143, 22)); 
-    add(lmoneda, null);
-    add(moneda , null);
-  }
-  /**
    * Linkeo los campos con la variables del form
    */
   public void InicializarPanel( JWin zWin ) throws Exception {
-    AddItem( company, CHAR, REQ, "company" ).setVisible(false);
-    AddItem( owner, CHAR, REQ, "owner" ).setVisible(false);
-    AddItem( idPDF, CHAR, REQ, "idPDF" );
-    AddItem( descripcion, CHAR, REQ, "descripcion" );
-    AddItem( direccion, CHAR, REQ, "direccion" );
-    AddItem( codigo_postal, CHAR, REQ, "codigo_postal" );
-    AddItem( IATA, CHAR, REQ, "IATA" );
-    AddItem( CIF, CHAR, REQ, "CIF" );
-    AddItem( localidad, CHAR, REQ, "localidad" );
-    AddItem( moneda, CHAR, REQ, "moneda" );
+    AddItemEdit( null, CHAR, REQ, "company" ).setHide(true);
+    AddItemEdit( null, CHAR, REQ, "owner" ).setHide(true);
 
-  } 
-}  //  @jve:decl-index=0:visual-constraint="10,10" 
+    JFormPanelResponsive row = AddItemRow();
+    row.AddItemEdit( "ID Liquidacion", CHAR, REQ, "idPDF" ).setSizeColumns(6);
+    row.AddItemEdit( "IATA", CHAR, REQ, "IATA" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Descripcion", CHAR, REQ, "descripcion" ).setSizeColumns(12);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Direccion", CHAR, REQ, "direccion" ).setSizeColumns(6);
+    row.AddItemEdit( "Codigo postal", CHAR, REQ, "codigo_postal" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Localidad", CHAR, REQ, "localidad" ).setSizeColumns(6);
+    row.AddItemEdit( "Clave Fiscal", CHAR, REQ, "CIF" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Moneda", CHAR, REQ, "moneda" ).setSizeColumns(6);
+  }
+}

--- a/src/pss/bsp/pdf/col/cabecera/FormColCabecera.java
+++ b/src/pss/bsp/pdf/col/cabecera/FormColCabecera.java
@@ -8,31 +8,33 @@ public class FormColCabecera extends JBaseForm {
 
   private static final long serialVersionUID = 1245253623694L;
 
-  public FormColCabecera() throws Exception {
-  }
+  public FormColCabecera() throws Exception {}
 
-  public GuiColCabecera getWin() {
-    return (GuiColCabecera) getBaseWin();
-  }
+  public GuiColCabecera getWin() { return (GuiColCabecera) getBaseWin(); }
 
-  public void InicializarPanel(JWin zWin) throws Exception {
-    AddItemEdit(null, CHAR, REQ, "company").setHide(true);
-    AddItemEdit(null, CHAR, REQ, "owner").setHide(true);
+  /**
+   * Linkeo los campos con la variables del form
+   */
+  public void InicializarPanel( JWin zWin ) throws Exception {
+    AddItemEdit( null, CHAR, REQ, "company" ).setHide(true);
+    AddItemEdit( null, CHAR, REQ, "owner" ).setHide(true);
 
     JFormPanelResponsive row = AddItemRow();
-    row.AddItemEdit("ID Liquidacion", CHAR, REQ, "idPDF").setSizeColumns(6);
-    row.AddItemEdit("Descripcion", CHAR, REQ, "descripcion").setSizeColumns(6);
+    row.AddItemEdit( "ID Liquidacion", CHAR, REQ, "idPDF" ).setSizeColumns(6);
+    row.AddItemEdit( "IATA", CHAR, REQ, "IATA" ).setSizeColumns(6);
 
     row = AddItemRow();
-    row.AddItemEdit("Direccion", CHAR, REQ, "direccion").setSizeColumns(6);
-    row.AddItemEdit("Codigo postal", CHAR, REQ, "codigo_postal").setSizeColumns(6);
+    row.AddItemEdit( "Descripcion", CHAR, REQ, "descripcion" ).setSizeColumns(12);
 
     row = AddItemRow();
-    row.AddItemEdit("IATA", CHAR, REQ, "IATA").setSizeColumns(6);
-    row.AddItemEdit("Clave Fiscal", CHAR, REQ, "CIF").setSizeColumns(6);
+    row.AddItemEdit( "Direccion", CHAR, REQ, "direccion" ).setSizeColumns(6);
+    row.AddItemEdit( "Codigo postal", CHAR, REQ, "codigo_postal" ).setSizeColumns(6);
 
     row = AddItemRow();
-    row.AddItemEdit("Localidad", CHAR, REQ, "localidad").setSizeColumns(6);
-    row.AddItemEdit("Moneda", CHAR, REQ, "moneda").setSizeColumns(6);
+    row.AddItemEdit( "Localidad", CHAR, REQ, "localidad" ).setSizeColumns(6);
+    row.AddItemEdit( "Clave Fiscal", CHAR, REQ, "CIF" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Moneda", CHAR, REQ, "moneda" ).setSizeColumns(6);
   }
 }

--- a/src/pss/bsp/pdf/cri/cabecera/FormCRiCabecera.java
+++ b/src/pss/bsp/pdf/cri/cabecera/FormCRiCabecera.java
@@ -1,131 +1,40 @@
-package  pss.bsp.pdf.cri.cabecera;
+package pss.bsp.pdf.cri.cabecera;
 
-import java.awt.Dimension;
-import java.awt.Rectangle;
-import pss.core.winUI.forms.JBaseForm;
-import pss.core.ui.components.*;
 import pss.core.win.JWin;
+import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
 
 public class FormCRiCabecera extends JBaseForm {
 
+  private static final long serialVersionUID = 1245253623694L;
 
-private static final long serialVersionUID = 1245253623694L;
-
-  JPssEdit company = new JPssEdit  ();
-JPssEdit owner = new JPssEdit  ();
-JPssLabel lidPDF = new JPssLabel();
-JPssEdit idPDF = new JPssEdit  ();
-JPssLabel ldescripcion = new JPssLabel();
-JPssEdit descripcion = new JPssEdit  ();
-JPssLabel ldireccion = new JPssLabel();
-JPssEdit direccion = new JPssEdit  ();
-JPssLabel lcodigo_postal = new JPssLabel();
-JPssEdit codigo_postal = new JPssEdit  ();
-JPssLabel lIATA = new JPssLabel();
-JPssEdit IATA = new JPssEdit  ();
-JPssLabel lCIF = new JPssLabel();
-JPssEdit CIF = new JPssEdit  ();
-JPssLabel llocalidad = new JPssLabel();
-JPssEdit localidad = new JPssEdit  ();
-JPssLabel lmoneda = new JPssLabel();
-JPssEdit moneda = new JPssEdit  ();
-
-
-  /**
-   * Constructor de la Clase
-   */
-  public FormCRiCabecera() throws Exception {
-    try { jbInit(); }
-    catch (Exception e) { e.printStackTrace(); } 
-  }
+  public FormCRiCabecera() throws Exception {}
 
   public GuiCRiCabecera getWin() { return (GuiCRiCabecera) getBaseWin(); }
 
   /**
-   * Inicializacion Grafica
-   */
-  protected void jbInit() throws Exception {
-    setLayout(null);
-    setSize(new Dimension(549, 150));
-
-
-    company.setBounds(new Rectangle(2, 5, 16, 22)); 
-    add(company , null);
-
-
-    owner.setBounds(new Rectangle(2, 31, 20, 22)); 
-    add(owner , null);
-
-
-    lidPDF.setText("ID Liquidacion");
-    lidPDF.setBounds(new Rectangle(30-20, 5, 123, 22)); 
-    idPDF.setBounds(new Rectangle(158-20, 5, 143, 22)); 
-    add(lidPDF, null);
-    add(idPDF , null);
-
-
-    ldescripcion.setText( "Descripcion" );
-    ldescripcion.setBounds(new Rectangle(30-20, 29, 123, 22)); 
-    descripcion.setBounds(new Rectangle(158-20, 29, 387, 22)); 
-    add(ldescripcion, null);
-    add(descripcion , null);
-
-
-    ldireccion.setText( "Direccion" );
-    ldireccion.setBounds(new Rectangle(30-20, 54, 123, 22)); 
-    direccion.setBounds(new Rectangle(158-20, 54, 143, 22)); 
-    add(ldireccion, null);
-    add(direccion , null);
-
-
-    lcodigo_postal.setText( "Codigo postal" );
-    lcodigo_postal.setBounds(new Rectangle(303-20, 54, 98, 22)); 
-    codigo_postal.setBounds(new Rectangle(403-20, 54, 143, 22)); 
-    add(lcodigo_postal, null);
-    add(codigo_postal , null);
-
-
-    lIATA.setText("IATA");
-    lIATA.setBounds(new Rectangle(303-20, 5, 98, 22)); 
-    IATA.setBounds(new Rectangle(403-20, 5, 143, 22)); 
-    add(lIATA, null);
-    add(IATA , null);
-
-
-    lCIF.setText("Clave Fiscal");
-    lCIF.setBounds(new Rectangle(303-20, 80, 98, 22)); 
-    CIF.setBounds(new Rectangle(403-20, 80, 143, 22)); 
-    add(lCIF, null);
-    add(CIF , null);
-
-
-    llocalidad.setText( "Localidad" );
-    llocalidad.setBounds(new Rectangle(30-20, 80, 123, 22)); 
-    localidad.setBounds(new Rectangle(158-20, 80, 143, 22)); 
-    add(llocalidad, null);
-    add(localidad , null);
-
-
-    lmoneda.setText( "Moneda" );
-    lmoneda.setBounds(new Rectangle(30-20, 106, 123, 22)); 
-    moneda.setBounds(new Rectangle(158-20, 106, 143, 22)); 
-    add(lmoneda, null);
-    add(moneda , null);
-  }
-  /**
    * Linkeo los campos con la variables del form
    */
   public void InicializarPanel( JWin zWin ) throws Exception {
-    AddItem( company, CHAR, REQ, "company" ).setVisible(false);
-    AddItem( owner, CHAR, REQ, "owner" ).setVisible(false);
-    AddItem( idPDF, CHAR, REQ, "idPDF" );
-    AddItem( descripcion, CHAR, REQ, "descripcion" );
-    AddItem( direccion, CHAR, REQ, "direccion" );
-    AddItem( codigo_postal, CHAR, REQ, "codigo_postal" );
-    AddItem( IATA, CHAR, REQ, "IATA" );
-    AddItem( CIF, CHAR, REQ, "CIF" );
-    AddItem( localidad, CHAR, REQ, "localidad" );
-    AddItem( moneda, CHAR, REQ, "moneda" );
+    AddItemEdit( null, CHAR, REQ, "company" ).setHide(true);
+    AddItemEdit( null, CHAR, REQ, "owner" ).setHide(true);
 
-  } 
-}  //  @jve:decl-index=0:visual-constraint="10,10" 
+    JFormPanelResponsive row = AddItemRow();
+    row.AddItemEdit( "ID Liquidacion", CHAR, REQ, "idPDF" ).setSizeColumns(6);
+    row.AddItemEdit( "IATA", CHAR, REQ, "IATA" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Descripcion", CHAR, REQ, "descripcion" ).setSizeColumns(12);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Direccion", CHAR, REQ, "direccion" ).setSizeColumns(6);
+    row.AddItemEdit( "Codigo postal", CHAR, REQ, "codigo_postal" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Localidad", CHAR, REQ, "localidad" ).setSizeColumns(6);
+    row.AddItemEdit( "Clave Fiscal", CHAR, REQ, "CIF" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Moneda", CHAR, REQ, "moneda" ).setSizeColumns(6);
+  }
+}

--- a/src/pss/bsp/pdf/ecu/cabecera/FormEcuCabecera.java
+++ b/src/pss/bsp/pdf/ecu/cabecera/FormEcuCabecera.java
@@ -1,131 +1,40 @@
-package  pss.bsp.pdf.ecu.cabecera;
+package pss.bsp.pdf.ecu.cabecera;
 
-import java.awt.Dimension;
-import java.awt.Rectangle;
-import pss.core.winUI.forms.JBaseForm;
-import pss.core.ui.components.*;
 import pss.core.win.JWin;
+import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
 
 public class FormEcuCabecera extends JBaseForm {
 
+  private static final long serialVersionUID = 1245253623694L;
 
-private static final long serialVersionUID = 1245253623694L;
-
-  JPssEdit company = new JPssEdit  ();
-JPssEdit owner = new JPssEdit  ();
-JPssLabel lidPDF = new JPssLabel();
-JPssEdit idPDF = new JPssEdit  ();
-JPssLabel ldescripcion = new JPssLabel();
-JPssEdit descripcion = new JPssEdit  ();
-JPssLabel ldireccion = new JPssLabel();
-JPssEdit direccion = new JPssEdit  ();
-JPssLabel lcodigo_postal = new JPssLabel();
-JPssEdit codigo_postal = new JPssEdit  ();
-JPssLabel lIATA = new JPssLabel();
-JPssEdit IATA = new JPssEdit  ();
-JPssLabel lCIF = new JPssLabel();
-JPssEdit CIF = new JPssEdit  ();
-JPssLabel llocalidad = new JPssLabel();
-JPssEdit localidad = new JPssEdit  ();
-JPssLabel lmoneda = new JPssLabel();
-JPssEdit moneda = new JPssEdit  ();
-
-
-  /**
-   * Constructor de la Clase
-   */
-  public FormEcuCabecera() throws Exception {
-    try { jbInit(); }
-    catch (Exception e) { e.printStackTrace(); } 
-  }
+  public FormEcuCabecera() throws Exception {}
 
   public GuiEcuCabecera getWin() { return (GuiEcuCabecera) getBaseWin(); }
 
   /**
-   * Inicializacion Grafica
-   */
-  protected void jbInit() throws Exception {
-    setLayout(null);
-    setSize(new Dimension(549, 150));
-
-
-    company.setBounds(new Rectangle(2, 5, 16, 22)); 
-    add(company , null);
-
-
-    owner.setBounds(new Rectangle(2, 31, 20, 22)); 
-    add(owner , null);
-
-
-    lidPDF.setText("ID Liquidacion");
-    lidPDF.setBounds(new Rectangle(30-20, 5, 123, 22)); 
-    idPDF.setBounds(new Rectangle(158-20, 5, 143, 22)); 
-    add(lidPDF, null);
-    add(idPDF , null);
-
-
-    ldescripcion.setText( "Descripcion" );
-    ldescripcion.setBounds(new Rectangle(30-20, 29, 123, 22)); 
-    descripcion.setBounds(new Rectangle(158-20, 29, 387, 22)); 
-    add(ldescripcion, null);
-    add(descripcion , null);
-
-
-    ldireccion.setText( "Direccion" );
-    ldireccion.setBounds(new Rectangle(30-20, 54, 123, 22)); 
-    direccion.setBounds(new Rectangle(158-20, 54, 143, 22)); 
-    add(ldireccion, null);
-    add(direccion , null);
-
-
-    lcodigo_postal.setText( "Codigo postal" );
-    lcodigo_postal.setBounds(new Rectangle(303-20, 54, 98, 22)); 
-    codigo_postal.setBounds(new Rectangle(403-20, 54, 143, 22)); 
-    add(lcodigo_postal, null);
-    add(codigo_postal , null);
-
-
-    lIATA.setText("IATA");
-    lIATA.setBounds(new Rectangle(303-20, 5, 98, 22)); 
-    IATA.setBounds(new Rectangle(403-20, 5, 143, 22)); 
-    add(lIATA, null);
-    add(IATA , null);
-
-
-    lCIF.setText("Clave Fiscal");
-    lCIF.setBounds(new Rectangle(303-20, 80, 98, 22)); 
-    CIF.setBounds(new Rectangle(403-20, 80, 143, 22)); 
-    add(lCIF, null);
-    add(CIF , null);
-
-
-    llocalidad.setText( "Localidad" );
-    llocalidad.setBounds(new Rectangle(30-20, 80, 123, 22)); 
-    localidad.setBounds(new Rectangle(158-20, 80, 143, 22)); 
-    add(llocalidad, null);
-    add(localidad , null);
-
-
-    lmoneda.setText( "Moneda" );
-    lmoneda.setBounds(new Rectangle(30-20, 106, 123, 22)); 
-    moneda.setBounds(new Rectangle(158-20, 106, 143, 22)); 
-    add(lmoneda, null);
-    add(moneda , null);
-  }
-  /**
    * Linkeo los campos con la variables del form
    */
   public void InicializarPanel( JWin zWin ) throws Exception {
-    AddItem( company, CHAR, REQ, "company" ).setVisible(false);
-    AddItem( owner, CHAR, REQ, "owner" ).setVisible(false);
-    AddItem( idPDF, CHAR, REQ, "idPDF" );
-    AddItem( descripcion, CHAR, REQ, "descripcion" );
-    AddItem( direccion, CHAR, REQ, "direccion" );
-    AddItem( codigo_postal, CHAR, REQ, "codigo_postal" );
-    AddItem( IATA, CHAR, REQ, "IATA" );
-    AddItem( CIF, CHAR, REQ, "CIF" );
-    AddItem( localidad, CHAR, REQ, "localidad" );
-    AddItem( moneda, CHAR, REQ, "moneda" );
+    AddItemEdit( null, CHAR, REQ, "company" ).setHide(true);
+    AddItemEdit( null, CHAR, REQ, "owner" ).setHide(true);
 
-  } 
-}  //  @jve:decl-index=0:visual-constraint="10,10" 
+    JFormPanelResponsive row = AddItemRow();
+    row.AddItemEdit( "ID Liquidacion", CHAR, REQ, "idPDF" ).setSizeColumns(6);
+    row.AddItemEdit( "IATA", CHAR, REQ, "IATA" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Descripcion", CHAR, REQ, "descripcion" ).setSizeColumns(12);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Direccion", CHAR, REQ, "direccion" ).setSizeColumns(6);
+    row.AddItemEdit( "Codigo postal", CHAR, REQ, "codigo_postal" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Localidad", CHAR, REQ, "localidad" ).setSizeColumns(6);
+    row.AddItemEdit( "Clave Fiscal", CHAR, REQ, "CIF" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Moneda", CHAR, REQ, "moneda" ).setSizeColumns(6);
+  }
+}

--- a/src/pss/bsp/pdf/gua/cabecera/FormGuaCabecera.java
+++ b/src/pss/bsp/pdf/gua/cabecera/FormGuaCabecera.java
@@ -1,131 +1,40 @@
-package  pss.bsp.pdf.gua.cabecera;
+package pss.bsp.pdf.gua.cabecera;
 
-import java.awt.Dimension;
-import java.awt.Rectangle;
-import pss.core.winUI.forms.JBaseForm;
-import pss.core.ui.components.*;
 import pss.core.win.JWin;
+import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
 
 public class FormGuaCabecera extends JBaseForm {
 
+  private static final long serialVersionUID = 1245253623694L;
 
-private static final long serialVersionUID = 1245253623694L;
-
-  JPssEdit company = new JPssEdit  ();
-JPssEdit owner = new JPssEdit  ();
-JPssLabel lidPDF = new JPssLabel();
-JPssEdit idPDF = new JPssEdit  ();
-JPssLabel ldescripcion = new JPssLabel();
-JPssEdit descripcion = new JPssEdit  ();
-JPssLabel ldireccion = new JPssLabel();
-JPssEdit direccion = new JPssEdit  ();
-JPssLabel lcodigo_postal = new JPssLabel();
-JPssEdit codigo_postal = new JPssEdit  ();
-JPssLabel lIATA = new JPssLabel();
-JPssEdit IATA = new JPssEdit  ();
-JPssLabel lCIF = new JPssLabel();
-JPssEdit CIF = new JPssEdit  ();
-JPssLabel llocalidad = new JPssLabel();
-JPssEdit localidad = new JPssEdit  ();
-JPssLabel lmoneda = new JPssLabel();
-JPssEdit moneda = new JPssEdit  ();
-
-
-  /**
-   * Constructor de la Clase
-   */
-  public FormGuaCabecera() throws Exception {
-    try { jbInit(); }
-    catch (Exception e) { e.printStackTrace(); } 
-  }
+  public FormGuaCabecera() throws Exception {}
 
   public GuiGuaCabecera getWin() { return (GuiGuaCabecera) getBaseWin(); }
 
   /**
-   * Inicializacion Grafica
-   */
-  protected void jbInit() throws Exception {
-    setLayout(null);
-    setSize(new Dimension(549, 150));
-
-
-    company.setBounds(new Rectangle(2, 5, 16, 22)); 
-    add(company , null);
-
-
-    owner.setBounds(new Rectangle(2, 31, 20, 22)); 
-    add(owner , null);
-
-
-    lidPDF.setText("ID Liquidacion");
-    lidPDF.setBounds(new Rectangle(30-20, 5, 123, 22)); 
-    idPDF.setBounds(new Rectangle(158-20, 5, 143, 22)); 
-    add(lidPDF, null);
-    add(idPDF , null);
-
-
-    ldescripcion.setText( "Descripcion" );
-    ldescripcion.setBounds(new Rectangle(30-20, 29, 123, 22)); 
-    descripcion.setBounds(new Rectangle(158-20, 29, 387, 22)); 
-    add(ldescripcion, null);
-    add(descripcion , null);
-
-
-    ldireccion.setText( "Direccion" );
-    ldireccion.setBounds(new Rectangle(30-20, 54, 123, 22)); 
-    direccion.setBounds(new Rectangle(158-20, 54, 143, 22)); 
-    add(ldireccion, null);
-    add(direccion , null);
-
-
-    lcodigo_postal.setText( "Codigo postal" );
-    lcodigo_postal.setBounds(new Rectangle(303-20, 54, 98, 22)); 
-    codigo_postal.setBounds(new Rectangle(403-20, 54, 143, 22)); 
-    add(lcodigo_postal, null);
-    add(codigo_postal , null);
-
-
-    lIATA.setText("IATA");
-    lIATA.setBounds(new Rectangle(303-20, 5, 98, 22)); 
-    IATA.setBounds(new Rectangle(403-20, 5, 143, 22)); 
-    add(lIATA, null);
-    add(IATA , null);
-
-
-    lCIF.setText("Clave Fiscal");
-    lCIF.setBounds(new Rectangle(303-20, 80, 98, 22)); 
-    CIF.setBounds(new Rectangle(403-20, 80, 143, 22)); 
-    add(lCIF, null);
-    add(CIF , null);
-
-
-    llocalidad.setText( "Localidad" );
-    llocalidad.setBounds(new Rectangle(30-20, 80, 123, 22)); 
-    localidad.setBounds(new Rectangle(158-20, 80, 143, 22)); 
-    add(llocalidad, null);
-    add(localidad , null);
-
-
-    lmoneda.setText( "Moneda" );
-    lmoneda.setBounds(new Rectangle(30-20, 106, 123, 22)); 
-    moneda.setBounds(new Rectangle(158-20, 106, 143, 22)); 
-    add(lmoneda, null);
-    add(moneda , null);
-  }
-  /**
    * Linkeo los campos con la variables del form
    */
   public void InicializarPanel( JWin zWin ) throws Exception {
-    AddItem( company, CHAR, REQ, "company" ).setVisible(false);
-    AddItem( owner, CHAR, REQ, "owner" ).setVisible(false);
-    AddItem( idPDF, CHAR, REQ, "idPDF" );
-    AddItem( descripcion, CHAR, REQ, "descripcion" );
-    AddItem( direccion, CHAR, REQ, "direccion" );
-    AddItem( codigo_postal, CHAR, REQ, "codigo_postal" );
-    AddItem( IATA, CHAR, REQ, "IATA" );
-    AddItem( CIF, CHAR, REQ, "CIF" );
-    AddItem( localidad, CHAR, REQ, "localidad" );
-    AddItem( moneda, CHAR, REQ, "moneda" );
+    AddItemEdit( null, CHAR, REQ, "company" ).setHide(true);
+    AddItemEdit( null, CHAR, REQ, "owner" ).setHide(true);
 
-  } 
-}  //  @jve:decl-index=0:visual-constraint="10,10" 
+    JFormPanelResponsive row = AddItemRow();
+    row.AddItemEdit( "ID Liquidacion", CHAR, REQ, "idPDF" ).setSizeColumns(6);
+    row.AddItemEdit( "IATA", CHAR, REQ, "IATA" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Descripcion", CHAR, REQ, "descripcion" ).setSizeColumns(12);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Direccion", CHAR, REQ, "direccion" ).setSizeColumns(6);
+    row.AddItemEdit( "Codigo postal", CHAR, REQ, "codigo_postal" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Localidad", CHAR, REQ, "localidad" ).setSizeColumns(6);
+    row.AddItemEdit( "Clave Fiscal", CHAR, REQ, "CIF" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Moneda", CHAR, REQ, "moneda" ).setSizeColumns(6);
+  }
+}

--- a/src/pss/bsp/pdf/mex/cabecera/FormMexCabecera.java
+++ b/src/pss/bsp/pdf/mex/cabecera/FormMexCabecera.java
@@ -1,131 +1,40 @@
-package  pss.bsp.pdf.mex.cabecera;
+package pss.bsp.pdf.mex.cabecera;
 
-import java.awt.Dimension;
-import java.awt.Rectangle;
-import pss.core.winUI.forms.JBaseForm;
-import pss.core.ui.components.*;
 import pss.core.win.JWin;
+import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
 
 public class FormMexCabecera extends JBaseForm {
 
+  private static final long serialVersionUID = 1245253623694L;
 
-private static final long serialVersionUID = 1245253623694L;
-
-  JPssEdit company = new JPssEdit  ();
-JPssEdit owner = new JPssEdit  ();
-JPssLabel lidPDF = new JPssLabel();
-JPssEdit idPDF = new JPssEdit  ();
-JPssLabel ldescripcion = new JPssLabel();
-JPssEdit descripcion = new JPssEdit  ();
-JPssLabel ldireccion = new JPssLabel();
-JPssEdit direccion = new JPssEdit  ();
-JPssLabel lcodigo_postal = new JPssLabel();
-JPssEdit codigo_postal = new JPssEdit  ();
-JPssLabel lIATA = new JPssLabel();
-JPssEdit IATA = new JPssEdit  ();
-JPssLabel lCIF = new JPssLabel();
-JPssEdit CIF = new JPssEdit  ();
-JPssLabel llocalidad = new JPssLabel();
-JPssEdit localidad = new JPssEdit  ();
-JPssLabel lmoneda = new JPssLabel();
-JPssEdit moneda = new JPssEdit  ();
-
-
-  /**
-   * Constructor de la Clase
-   */
-  public FormMexCabecera() throws Exception {
-    try { jbInit(); }
-    catch (Exception e) { e.printStackTrace(); } 
-  }
+  public FormMexCabecera() throws Exception {}
 
   public GuiMexCabecera getWin() { return (GuiMexCabecera) getBaseWin(); }
 
   /**
-   * Inicializacion Grafica
-   */
-  protected void jbInit() throws Exception {
-    setLayout(null);
-    setSize(new Dimension(549, 150));
-
-
-    company.setBounds(new Rectangle(2, 5, 16, 22)); 
-    add(company , null);
-
-
-    owner.setBounds(new Rectangle(2, 31, 20, 22)); 
-    add(owner , null);
-
-
-    lidPDF.setText("ID Liquidacion");
-    lidPDF.setBounds(new Rectangle(30-20, 5, 123, 22)); 
-    idPDF.setBounds(new Rectangle(158-20, 5, 143, 22)); 
-    add(lidPDF, null);
-    add(idPDF , null);
-
-
-    ldescripcion.setText( "Descripcion" );
-    ldescripcion.setBounds(new Rectangle(30-20, 29, 123, 22)); 
-    descripcion.setBounds(new Rectangle(158-20, 29, 387, 22)); 
-    add(ldescripcion, null);
-    add(descripcion , null);
-
-
-    ldireccion.setText( "Direccion" );
-    ldireccion.setBounds(new Rectangle(30-20, 54, 123, 22)); 
-    direccion.setBounds(new Rectangle(158-20, 54, 143, 22)); 
-    add(ldireccion, null);
-    add(direccion , null);
-
-
-    lcodigo_postal.setText( "Codigo postal" );
-    lcodigo_postal.setBounds(new Rectangle(303-20, 54, 98, 22)); 
-    codigo_postal.setBounds(new Rectangle(403-20, 54, 143, 22)); 
-    add(lcodigo_postal, null);
-    add(codigo_postal , null);
-
-
-    lIATA.setText("IATA");
-    lIATA.setBounds(new Rectangle(303-20, 5, 98, 22)); 
-    IATA.setBounds(new Rectangle(403-20, 5, 143, 22)); 
-    add(lIATA, null);
-    add(IATA , null);
-
-
-    lCIF.setText("Clave Fiscal");
-    lCIF.setBounds(new Rectangle(303-20, 80, 98, 22)); 
-    CIF.setBounds(new Rectangle(403-20, 80, 143, 22)); 
-    add(lCIF, null);
-    add(CIF , null);
-
-
-    llocalidad.setText( "Localidad" );
-    llocalidad.setBounds(new Rectangle(30-20, 80, 123, 22)); 
-    localidad.setBounds(new Rectangle(158-20, 80, 143, 22)); 
-    add(llocalidad, null);
-    add(localidad , null);
-
-
-    lmoneda.setText( "Moneda" );
-    lmoneda.setBounds(new Rectangle(30-20, 106, 123, 22)); 
-    moneda.setBounds(new Rectangle(158-20, 106, 143, 22)); 
-    add(lmoneda, null);
-    add(moneda , null);
-  }
-  /**
    * Linkeo los campos con la variables del form
    */
   public void InicializarPanel( JWin zWin ) throws Exception {
-    AddItem( company, CHAR, REQ, "company" ).setVisible(false);
-    AddItem( owner, CHAR, REQ, "owner" ).setVisible(false);
-    AddItem( idPDF, CHAR, REQ, "idPDF" );
-    AddItem( descripcion, CHAR, REQ, "descripcion" );
-    AddItem( direccion, CHAR, REQ, "direccion" );
-    AddItem( codigo_postal, CHAR, REQ, "codigo_postal" );
-    AddItem( IATA, CHAR, REQ, "IATA" );
-    AddItem( CIF, CHAR, REQ, "CIF" );
-    AddItem( localidad, CHAR, REQ, "localidad" );
-    AddItem( moneda, CHAR, REQ, "moneda" );
+    AddItemEdit( null, CHAR, REQ, "company" ).setHide(true);
+    AddItemEdit( null, CHAR, REQ, "owner" ).setHide(true);
 
-  } 
-}  //  @jve:decl-index=0:visual-constraint="10,10" 
+    JFormPanelResponsive row = AddItemRow();
+    row.AddItemEdit( "ID Liquidacion", CHAR, REQ, "idPDF" ).setSizeColumns(6);
+    row.AddItemEdit( "IATA", CHAR, REQ, "IATA" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Descripcion", CHAR, REQ, "descripcion" ).setSizeColumns(12);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Direccion", CHAR, REQ, "direccion" ).setSizeColumns(6);
+    row.AddItemEdit( "Codigo postal", CHAR, REQ, "codigo_postal" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Localidad", CHAR, REQ, "localidad" ).setSizeColumns(6);
+    row.AddItemEdit( "Clave Fiscal", CHAR, REQ, "CIF" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Moneda", CHAR, REQ, "moneda" ).setSizeColumns(6);
+  }
+}

--- a/src/pss/bsp/pdf/pan/cabecera/FormPanCabecera.java
+++ b/src/pss/bsp/pdf/pan/cabecera/FormPanCabecera.java
@@ -1,131 +1,40 @@
-package  pss.bsp.pdf.pan.cabecera;
+package pss.bsp.pdf.pan.cabecera;
 
-import java.awt.Dimension;
-import java.awt.Rectangle;
-import pss.core.winUI.forms.JBaseForm;
-import pss.core.ui.components.*;
 import pss.core.win.JWin;
+import pss.core.winUI.forms.JBaseForm;
+import pss.core.winUI.responsiveControls.JFormPanelResponsive;
 
 public class FormPanCabecera extends JBaseForm {
 
+  private static final long serialVersionUID = 1245253623694L;
 
-private static final long serialVersionUID = 1245253623694L;
-
-  JPssEdit company = new JPssEdit  ();
-JPssEdit owner = new JPssEdit  ();
-JPssLabel lidPDF = new JPssLabel();
-JPssEdit idPDF = new JPssEdit  ();
-JPssLabel ldescripcion = new JPssLabel();
-JPssEdit descripcion = new JPssEdit  ();
-JPssLabel ldireccion = new JPssLabel();
-JPssEdit direccion = new JPssEdit  ();
-JPssLabel lcodigo_postal = new JPssLabel();
-JPssEdit codigo_postal = new JPssEdit  ();
-JPssLabel lIATA = new JPssLabel();
-JPssEdit IATA = new JPssEdit  ();
-JPssLabel lCIF = new JPssLabel();
-JPssEdit CIF = new JPssEdit  ();
-JPssLabel llocalidad = new JPssLabel();
-JPssEdit localidad = new JPssEdit  ();
-JPssLabel lmoneda = new JPssLabel();
-JPssEdit moneda = new JPssEdit  ();
-
-
-  /**
-   * Constructor de la Clase
-   */
-  public FormPanCabecera() throws Exception {
-    try { jbInit(); }
-    catch (Exception e) { e.printStackTrace(); } 
-  }
+  public FormPanCabecera() throws Exception {}
 
   public GuiPanCabecera getWin() { return (GuiPanCabecera) getBaseWin(); }
 
   /**
-   * Inicializacion Grafica
-   */
-  protected void jbInit() throws Exception {
-    setLayout(null);
-    setSize(new Dimension(549, 150));
-
-
-    company.setBounds(new Rectangle(2, 5, 16, 22)); 
-    add(company , null);
-
-
-    owner.setBounds(new Rectangle(2, 31, 20, 22)); 
-    add(owner , null);
-
-
-    lidPDF.setText("ID Liquidacion");
-    lidPDF.setBounds(new Rectangle(30-20, 5, 123, 22)); 
-    idPDF.setBounds(new Rectangle(158-20, 5, 143, 22)); 
-    add(lidPDF, null);
-    add(idPDF , null);
-
-
-    ldescripcion.setText( "Descripcion" );
-    ldescripcion.setBounds(new Rectangle(30-20, 29, 123, 22)); 
-    descripcion.setBounds(new Rectangle(158-20, 29, 387, 22)); 
-    add(ldescripcion, null);
-    add(descripcion , null);
-
-
-    ldireccion.setText( "Direccion" );
-    ldireccion.setBounds(new Rectangle(30-20, 54, 123, 22)); 
-    direccion.setBounds(new Rectangle(158-20, 54, 143, 22)); 
-    add(ldireccion, null);
-    add(direccion , null);
-
-
-    lcodigo_postal.setText( "Codigo postal" );
-    lcodigo_postal.setBounds(new Rectangle(303-20, 54, 98, 22)); 
-    codigo_postal.setBounds(new Rectangle(403-20, 54, 143, 22)); 
-    add(lcodigo_postal, null);
-    add(codigo_postal , null);
-
-
-    lIATA.setText("IATA");
-    lIATA.setBounds(new Rectangle(303-20, 5, 98, 22)); 
-    IATA.setBounds(new Rectangle(403-20, 5, 143, 22)); 
-    add(lIATA, null);
-    add(IATA , null);
-
-
-    lCIF.setText("Clave Fiscal");
-    lCIF.setBounds(new Rectangle(303-20, 80, 98, 22)); 
-    CIF.setBounds(new Rectangle(403-20, 80, 143, 22)); 
-    add(lCIF, null);
-    add(CIF , null);
-
-
-    llocalidad.setText( "Localidad" );
-    llocalidad.setBounds(new Rectangle(30-20, 80, 123, 22)); 
-    localidad.setBounds(new Rectangle(158-20, 80, 143, 22)); 
-    add(llocalidad, null);
-    add(localidad , null);
-
-
-    lmoneda.setText( "Moneda" );
-    lmoneda.setBounds(new Rectangle(30-20, 106, 123, 22)); 
-    moneda.setBounds(new Rectangle(158-20, 106, 143, 22)); 
-    add(lmoneda, null);
-    add(moneda , null);
-  }
-  /**
    * Linkeo los campos con la variables del form
    */
   public void InicializarPanel( JWin zWin ) throws Exception {
-    AddItem( company, CHAR, REQ, "company" ).setVisible(false);
-    AddItem( owner, CHAR, REQ, "owner" ).setVisible(false);
-    AddItem( idPDF, CHAR, REQ, "idPDF" );
-    AddItem( descripcion, CHAR, REQ, "descripcion" );
-    AddItem( direccion, CHAR, REQ, "direccion" );
-    AddItem( codigo_postal, CHAR, REQ, "codigo_postal" );
-    AddItem( IATA, CHAR, REQ, "IATA" );
-    AddItem( CIF, CHAR, REQ, "CIF" );
-    AddItem( localidad, CHAR, REQ, "localidad" );
-    AddItem( moneda, CHAR, REQ, "moneda" );
+    AddItemEdit( null, CHAR, REQ, "company" ).setHide(true);
+    AddItemEdit( null, CHAR, REQ, "owner" ).setHide(true);
 
-  } 
-}  //  @jve:decl-index=0:visual-constraint="10,10" 
+    JFormPanelResponsive row = AddItemRow();
+    row.AddItemEdit( "ID Liquidacion", CHAR, REQ, "idPDF" ).setSizeColumns(6);
+    row.AddItemEdit( "IATA", CHAR, REQ, "IATA" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Descripcion", CHAR, REQ, "descripcion" ).setSizeColumns(12);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Direccion", CHAR, REQ, "direccion" ).setSizeColumns(6);
+    row.AddItemEdit( "Codigo postal", CHAR, REQ, "codigo_postal" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Localidad", CHAR, REQ, "localidad" ).setSizeColumns(6);
+    row.AddItemEdit( "Clave Fiscal", CHAR, REQ, "CIF" ).setSizeColumns(6);
+
+    row = AddItemRow();
+    row.AddItemEdit( "Moneda", CHAR, REQ, "moneda" ).setSizeColumns(6);
+  }
+}


### PR DESCRIPTION
## Summary
- Replace legacy component layout in `pss.bsp.pdf` cabecera forms with responsive `AddItemRow` usage following `FormBooking` style.
- Hide internal fields like `company` and `owner` and organize remaining fields into responsive rows across all country-specific cabecera forms.

## Testing
- `mvn -q -e test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a55f10c388333b88f766242e55892