### PR TITLE
refactor: encapsulate registered object maps

### DIFF
--- a/src/pss/www/platform/actions/JWebWinFactory.java
+++ b/src/pss/www/platform/actions/JWebWinFactory.java
@@ -693,15 +693,15 @@ public class JWebWinFactory {
 //			if (field.getName().equals("previousPriceQuantity"))
 //			PssLogger.logDebug(field.getName()+"="+field.getValue());
 
-			String value = field.getValue();
-			Object obj = null;
-			if (value.startsWith("obj_")) {
-				if (value.startsWith("obj_t_")) {
-					obj = getRegisterObjectTemp(value.substring(6));
-				} else {
-					obj = JWebActionFactory.getCurrentRequest().getRegisterObject(value);
-				}
-			}
+                        String value = field.getValue();
+                        Object obj = null;
+                        if (value.startsWith("obj_")) {
+                                if (value.startsWith(JWebRequest.OBJ_T_UNDERSCORE_PREFIX)) {
+                                        obj = getRegisterObjectTemp(value.substring(JWebRequest.OBJ_T_UNDERSCORE_PREFIX.length()));
+                                } else {
+                                        obj = JWebActionFactory.getCurrentRequest().getRegisterObject(value);
+                                }
+                        }
 			if (prop.isRecord()) {
 				if (obj != null && obj instanceof JWin)
 					prop.setValue(record.getPropValue(field.getName(), prop, ((JWin) obj).getRecord()));

--- a/src/pss/www/platform/actions/JWinPackager.java
+++ b/src/pss/www/platform/actions/JWinPackager.java
@@ -268,16 +268,16 @@ public class JWinPackager {
 			return;
 		JRecords recs = (JRecords<JRecord>) actionOwner;
 		recs.setStatic(true);
-		for (String element : serializableWin.elements) {
-			if (element.startsWith("obj_rec_")) {
-				recs.getStaticItems().addElement(getRegisterObjectRecTemp(element.substring(8)));
-			} else {
-				Serializable obj = JWebActionFactory.getCurrentRequest().getRegisterObject(element);
-				if (obj instanceof JBaseRecord) {
-					recs.getStaticItems().addElement((JBaseRecord) obj);
-				}
-			}
-		}
+                for (String element : serializableWin.elements) {
+                        if (element.startsWith(JWebRequest.OBJ_REC_UNDERSCORE_PREFIX)) {
+                                recs.getStaticItems().addElement(getRegisterObjectRecTemp(element.substring(JWebRequest.OBJ_REC_UNDERSCORE_PREFIX.length())));
+                        } else {
+                                Serializable obj = JWebActionFactory.getCurrentRequest().getRegisterObject(element);
+                                if (obj instanceof JBaseRecord) {
+                                        recs.getStaticItems().addElement((JBaseRecord) obj);
+                                }
+                        }
+                }
 
 	}
 
@@ -292,20 +292,20 @@ public class JWinPackager {
 			String fieldKey = entry.getKey();
 			String propValue = entry.getValue();
 
-			if (fieldKey.startsWith("REC_")) {
-				JObject<?> obj = ((JRecord) actionOwner).getProp(fieldKey.substring(4));
-				if (propValue.startsWith("obj_rec_")) {
-					obj.setValue(getRegisterObjectRecTemp(propValue.substring(8)));
-				} else {
-					obj.setValue((JBaseRecord) JWebActionFactory.getCurrentRequest().getRegisterObject(propValue));
-				}
-			} else if (fieldKey.startsWith("RECS_")) {
-				JObject<?> obj = ((JRecord) actionOwner).getProp(fieldKey.substring(5));
-				if (propValue.startsWith("obj_rec_")) {
-					obj.setValue(getRegisterObjectRecTemp(propValue.substring(8)));
-				} else {
-					obj.setValue((JBaseRecord) JWebActionFactory.getCurrentRequest().getRegisterObject(propValue));
-				}
+                        if (fieldKey.startsWith("REC_")) {
+                                JObject<?> obj = ((JRecord) actionOwner).getProp(fieldKey.substring(4));
+                                if (propValue.startsWith(JWebRequest.OBJ_REC_UNDERSCORE_PREFIX)) {
+                                        obj.setValue(getRegisterObjectRecTemp(propValue.substring(JWebRequest.OBJ_REC_UNDERSCORE_PREFIX.length())));
+                                } else {
+                                        obj.setValue((JBaseRecord) JWebActionFactory.getCurrentRequest().getRegisterObject(propValue));
+                                }
+                        } else if (fieldKey.startsWith("RECS_")) {
+                                JObject<?> obj = ((JRecord) actionOwner).getProp(fieldKey.substring(5));
+                                if (propValue.startsWith(JWebRequest.OBJ_REC_UNDERSCORE_PREFIX)) {
+                                        obj.setValue(getRegisterObjectRecTemp(propValue.substring(JWebRequest.OBJ_REC_UNDERSCORE_PREFIX.length())));
+                                } else {
+                                        obj.setValue((JBaseRecord) JWebActionFactory.getCurrentRequest().getRegisterObject(propValue));
+                                }
 			} else if (fieldKey.startsWith("UID_")) {
 				JObject<?> obj = ((JRecord) actionOwner).getProp(fieldKey.substring(4));
 				obj.setUniqueId(propValue);
@@ -322,29 +322,29 @@ public class JWinPackager {
 				} catch (NoSuchFieldException | IllegalAccessException e) {
 					System.err.println("Error al asignar campo OTH: " + fieldName + " -> " + e.getMessage());
 				}
-			} else if (fieldKey.startsWith("SREC_")) {
-				Field field = currentClass.getDeclaredField(fieldKey.substring(5));
-				field.setAccessible(true);
-				JBaseRecord obj;
-				if (propValue.startsWith("obj_rec_")) {
-					obj = getRegisterObjectRecTemp(propValue.substring(8));
-				} else {
-					obj = (JBaseRecord) JWebActionFactory.getCurrentRequest().getRegisterObject(propValue);
-				}
-				field.set(actionOwner, obj);
-			} else if (fieldKey.startsWith("SRECS_")) {
-				Field field = currentClass.getDeclaredField(fieldKey.substring(6));
-				field.setAccessible(true);
-				JBaseRecord obj;
-				if (propValue.startsWith("obj_rec_")) {
-					obj = getRegisterObjectRecTemp(propValue.substring(8));
-				} else {
-					obj = (JBaseRecord) JWebActionFactory.getCurrentRequest().getRegisterObject(propValue);
-				}
-				field.set(actionOwner, obj);
-			} else if (fieldKey.startsWith("SER_")) {
-				String fieldName = fieldKey.substring(4);
-				try {
+                        } else if (fieldKey.startsWith("SREC_")) {
+                                Field field = currentClass.getDeclaredField(fieldKey.substring(5));
+                                field.setAccessible(true);
+                                JBaseRecord obj;
+                                if (propValue.startsWith(JWebRequest.OBJ_REC_UNDERSCORE_PREFIX)) {
+                                        obj = getRegisterObjectRecTemp(propValue.substring(JWebRequest.OBJ_REC_UNDERSCORE_PREFIX.length()));
+                                } else {
+                                        obj = (JBaseRecord) JWebActionFactory.getCurrentRequest().getRegisterObject(propValue);
+                                }
+                                field.set(actionOwner, obj);
+                        } else if (fieldKey.startsWith("SRECS_")) {
+                                Field field = currentClass.getDeclaredField(fieldKey.substring(6));
+                                field.setAccessible(true);
+                                JBaseRecord obj;
+                                if (propValue.startsWith(JWebRequest.OBJ_REC_UNDERSCORE_PREFIX)) {
+                                        obj = getRegisterObjectRecTemp(propValue.substring(JWebRequest.OBJ_REC_UNDERSCORE_PREFIX.length()));
+                                } else {
+                                        obj = (JBaseRecord) JWebActionFactory.getCurrentRequest().getRegisterObject(propValue);
+                                }
+                                field.set(actionOwner, obj);
+                        } else if (fieldKey.startsWith("SER_")) {
+                                String fieldName = fieldKey.substring(4);
+                                try {
 					Field field = currentClass.getDeclaredField(fieldName);
 					field.setAccessible(true);
 

--- a/src/pss/www/platform/actions/resolvers/JDoPssActionResolver.java
+++ b/src/pss/www/platform/actions/resolvers/JDoPssActionResolver.java
@@ -316,15 +316,15 @@ public class JDoPssActionResolver extends JIndoorsActionResolver implements ICon
 //			if (field.getName().equals("previousPriceQuantity"))
 //			PssLogger.logDebug(field.getName()+"="+field.getValue());
 
-			String value = field.getValue();
-			Object obj = null;
-			if (value.startsWith("obj_")) {
-				if (value.startsWith("obj_t_")) {
-					obj = winFactory.getRegisterObjectTemp(value.substring(6));
-				} else {
-					obj = JWebActionFactory.getCurrentRequest().getRegisterObject(value);
-				}
-			}
+                        String value = field.getValue();
+                        Object obj = null;
+                        if (value.startsWith("obj_")) {
+                                if (value.startsWith(JWebRequest.OBJ_T_UNDERSCORE_PREFIX)) {
+                                        obj = winFactory.getRegisterObjectTemp(value.substring(JWebRequest.OBJ_T_UNDERSCORE_PREFIX.length()));
+                                } else {
+                                        obj = JWebActionFactory.getCurrentRequest().getRegisterObject(value);
+                                }
+                        }
 			if (prop.isRecord()) {
 				if (obj != null && obj instanceof JWin)
 					prop.setValue(record.getPropValue(field.getName(), prop, ((JWin) obj).getRecord()));


### PR DESCRIPTION
## Summary
- add helpers for registering objects and fetching existing entries
- replace literal prefixes with constants and length-based substring operations
- update factories and resolvers to use centralized prefixes
- centralize payload and cache prefixes for object registration

## Testing
- `javac -encoding ISO-8859-1 -d /tmp/javac_out -cp src:rs/WEB-INF/lib/* src/pss/www/platform/actions/JWebRequest.java` *(fails: unclosed character literal in JTools.java)*

------
https://chatgpt.com/codex/tasks/task_e_689b1e9822008333bf94a39a67b72836