### PR TITLE
Add no-arg constructors to JAct subclasses

### DIFF
--- a/src/pss/core/win/submits/JActBack.java
+++ b/src/pss/core/win/submits/JActBack.java
@@ -27,6 +27,11 @@ public class JActBack extends JAct {
 	 */
 	private static final long serialVersionUID = 1861951660654597358L;
 
+	public JActBack() {
+		super();
+	}
+
+
 	// private JBaseForm form;
 	int backStep = 1;
 

--- a/src/pss/core/win/submits/JActChildForm.java
+++ b/src/pss/core/win/submits/JActChildForm.java
@@ -12,6 +12,11 @@ public class JActChildForm extends JActModify {
  */
 private static final long serialVersionUID = 2799749949633327989L;
 
+	public JActChildForm() {
+		super();
+	}
+
+
 public JActChildForm(JWin zparent, JWin zResult, int zActionId) {
 	super(zResult, zActionId);
 	historyAction=true;

--- a/src/pss/core/win/submits/JActDelete.java
+++ b/src/pss/core/win/submits/JActDelete.java
@@ -16,6 +16,11 @@ public class JActDelete extends JAct {
 	 */
 	private static final long serialVersionUID = 2942000940720499429L;
 
+	public JActDelete() {
+		super();
+	}
+
+
 	public JActDelete(JBaseWin zResult, int zActionId) {
 		super(zResult, zActionId);
 	}

--- a/src/pss/core/win/submits/JActDrop.java
+++ b/src/pss/core/win/submits/JActDrop.java
@@ -10,6 +10,11 @@ public class JActDrop extends JAct {
 	 * 
 	 */
 	private static final long serialVersionUID = 5672707536896804453L;
+
+	public JActDrop() {
+		super();
+	}
+
 	private JBaseWin oDropListener;
 
 

--- a/src/pss/core/win/submits/JActExternalLink.java
+++ b/src/pss/core/win/submits/JActExternalLink.java
@@ -14,6 +14,11 @@ public class JActExternalLink extends JActSubmit {
 	 * 
 	 */
 	private static final long serialVersionUID = -8671110613347096282L;
+
+	public JActExternalLink() {
+		super();
+	}
+
 	private String url;
 	
 	public String getUrl() {

--- a/src/pss/core/win/submits/JActFieldSwapWins.java
+++ b/src/pss/core/win/submits/JActFieldSwapWins.java
@@ -6,6 +6,10 @@ import pss.core.win.JBaseWin;
 import pss.core.win.JWins;
 
 public class JActFieldSwapWins extends JActWins {
+	public JActFieldSwapWins() {
+		super();
+	}
+
 
 	JWins selecteds;
 	JWins options;

--- a/src/pss/core/win/submits/JActFieldWins.java
+++ b/src/pss/core/win/submits/JActFieldWins.java
@@ -9,6 +9,10 @@ import pss.core.win.JWin;
 import pss.core.win.JWins;
 
 public class JActFieldWins extends JActWins {
+	public JActFieldWins() {
+		super();
+	}
+
 
 	JWin winSource;
 	String field;

--- a/src/pss/core/win/submits/JActFileGenerate.java
+++ b/src/pss/core/win/submits/JActFileGenerate.java
@@ -10,6 +10,11 @@ public class JActFileGenerate extends JActSubmit {
 	 * 
 	 */
 	private static final long serialVersionUID = -8671110613347096283L;
+
+	public JActFileGenerate() {
+		super();
+	}
+
 	private String fileName;
 //	private String pathProvider;
 	

--- a/src/pss/core/win/submits/JActGroupSubmit.java
+++ b/src/pss/core/win/submits/JActGroupSubmit.java
@@ -4,6 +4,10 @@ import pss.core.win.JWins;
 
 
 public class JActGroupSubmit extends JAct {
+	public JActGroupSubmit() {
+		super();
+	}
+
 	
 	JAct actSubmit;
 	

--- a/src/pss/core/win/submits/JActModify.java
+++ b/src/pss/core/win/submits/JActModify.java
@@ -13,6 +13,10 @@ import pss.core.winUI.forms.JBaseForm;
  * </p>
  */
 public abstract class JActModify extends JAct {
+	public JActModify() {
+		super();
+	}
+
 
 
 	/**

--- a/src/pss/core/win/submits/JActMultiSubmit.java
+++ b/src/pss/core/win/submits/JActMultiSubmit.java
@@ -12,6 +12,11 @@ public class JActMultiSubmit extends JAct {
 	 * 
 	 */
 	private static final long serialVersionUID = 6166414369116254357L;
+
+	public JActMultiSubmit() {
+		super();
+	}
+
 	JList<JAct> actionsList = null; 
 	JAct nextAction=null;
 	

--- a/src/pss/core/win/submits/JActNew.java
+++ b/src/pss/core/win/submits/JActNew.java
@@ -17,6 +17,11 @@ public class JActNew extends JActModify {
 	 * 
 	 */
 	private static final long serialVersionUID = 8861951660654597358L;
+
+	public JActNew() {
+		super();
+	}
+
 	private boolean updIfRead=false;
 	private boolean bNewForm=false;
 	private boolean bNoWas=true;

--- a/src/pss/core/win/submits/JActNewSubmit.java
+++ b/src/pss/core/win/submits/JActNewSubmit.java
@@ -15,6 +15,11 @@ public class JActNewSubmit extends JAct {
 	 * 
 	 */
 	private static final long serialVersionUID = 5580988789646653029L;
+
+	public JActNewSubmit() {
+		super();
+	}
+
 	
 	public JActNewSubmit(JBaseWin zResult, int zActionId, boolean zKeepForm) {
 		super(zResult, zActionId);
@@ -27,7 +32,7 @@ public class JActNewSubmit extends JAct {
 	
 //	@Override
 //	public void Do() throws Exception {
-//		if (!UITools.showConfirmation("Confirmación", "¿Está seguro?"))
+//		if (!UITools.showConfirmation("ConfirmaciÃ³n", "Â¿EstÃ¡ seguro?"))
 //			return;
 //		this.submit();
 //	}	

--- a/src/pss/core/win/submits/JActOptions.java
+++ b/src/pss/core/win/submits/JActOptions.java
@@ -4,6 +4,10 @@ import pss.core.win.JBaseWin;
 import pss.core.win.JWins;
 
 public class JActOptions extends JActWins {
+	public JActOptions() {
+		super();
+	}
+
 	
 	String question;
 

--- a/src/pss/core/win/submits/JActQueryActive.java
+++ b/src/pss/core/win/submits/JActQueryActive.java
@@ -11,6 +11,11 @@ public class JActQueryActive  extends JActModify {
 	 */
 	private static final long serialVersionUID = 4568131727914487531L;
 
+	public JActQueryActive() {
+		super();
+	}
+
+
 
 	public JActQueryActive(JBaseWin zResult) {
 		super(zResult,-1);

--- a/src/pss/core/win/submits/JActReport.java
+++ b/src/pss/core/win/submits/JActReport.java
@@ -15,6 +15,11 @@ public class JActReport extends JActFileGenerate {
 	 */
 	private static final long serialVersionUID = -2199579210846916239L;
 
+	public JActReport() {
+		super();
+	}
+
+
 	public JActReport(JBaseWin zResult, int zActionId) {
 		super(zResult, zActionId);
 	}

--- a/src/pss/core/win/submits/JActSubmit.java
+++ b/src/pss/core/win/submits/JActSubmit.java
@@ -17,6 +17,11 @@ public class JActSubmit extends JAct {
 	 */
 	private static final long serialVersionUID = -3316292953453369454L;
 
+	public JActSubmit() {
+		super();
+	}
+
+
 	public JActSubmit(JBaseWin zResult, int zActionId) {
 		super(zResult, zActionId);
 	}

--- a/src/pss/core/win/submits/JActUpdate.java
+++ b/src/pss/core/win/submits/JActUpdate.java
@@ -21,6 +21,11 @@ public class JActUpdate extends JActModify {
 	 */
 	private static final long serialVersionUID = 2799749949633327989L;
 
+	public JActUpdate() {
+		super();
+	}
+
+
 	public JActUpdate(JWin zResult, int zActionId) {
 		super(zResult, zActionId);
 		historyAction=true;

--- a/src/pss/core/win/submits/JActWins.java
+++ b/src/pss/core/win/submits/JActWins.java
@@ -14,6 +14,10 @@ import pss.core.win.JWins;
  * </p>
  */
 public class JActWins extends JAct {
+	public JActWins() {
+		super();
+	}
+
 	
 	private boolean bMultiple=true;
 	private boolean bLineSelect=true;

--- a/src/pss/core/win/submits/JActWinsSelect.java
+++ b/src/pss/core/win/submits/JActWinsSelect.java
@@ -5,6 +5,10 @@ import pss.core.win.JWins;
 
 
 public class JActWinsSelect extends JActWins {
+	public JActWinsSelect() {
+		super();
+	}
+
 	
 
 	public JActWinsSelect(JWins zWins, JBaseWin listener, boolean zMulti) throws Exception {


### PR DESCRIPTION
## Summary
- ensure every class deriving from `JAct` defines an explicit no-argument constructor for consistent instantiation

## Testing
- `javac -encoding ISO-8859-1 -d /tmp/out $(git ls-files 'src/pss/core/win/submits/JAct*.java')` *(fails: package pss.core.services does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689bcc6cdcbc83339d0ee985a85d33ab