### PR TITLE
Avoid recursive record serialization to prevent StackOverflow

### DIFF
--- a/src/pss/www/platform/actions/JWinPackager.java
+++ b/src/pss/www/platform/actions/JWinPackager.java
@@ -32,6 +32,22 @@ import pss.www.platform.cache.CacheProvider;
 
 public class JWinPackager {
 
+       // Evita recursión al serializar recs anidados
+       private static final ThreadLocal<java.util.Set<String>> SERIALIZING_KEYS =
+                       ThreadLocal.withInitial(java.util.HashSet::new);
+
+       static boolean isSerializingKey(String key) {
+               return SERIALIZING_KEYS.get().contains(key);
+       }
+
+       private static void markSerializingKey(String key) {
+               SERIALIZING_KEYS.get().add(key);
+       }
+
+       private static void unmarkSerializingKey(String key) {
+               SERIALIZING_KEYS.get().remove(key);
+       }
+
 	private final JWebWinFactory factory;
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -99,25 +115,45 @@ public class JWinPackager {
 		}
 	}
 
-	public JBaseRecord getRegisterObjectRecTemp(String zKey) throws Exception {
-		try {
-			return createRecFromPack(zKey, null);
-		} catch (Exception e) {
-			byte[] decoded;
-			try {
-				decoded = java.util.Base64.getUrlDecoder().decode(zKey);
-			} catch (IllegalArgumentException ex) {
-				decoded = java.util.Base64.getDecoder().decode(zKey);
-			}
-			String json;
-			try {
-				json = new String(inflate(decoded), StandardCharsets.UTF_8);
-			} catch (Exception ex2) {
-				json = JTools.byteVectorToString(decoded);
-			}
-			return createRecFromJson(json, null);
-		}
-	}
+       public JBaseRecord getRegisterObjectRecTemp(String zKey) throws Exception {
+               try {
+                       // 1) Intentar como referencia de cache (clave directa)
+                       byte[] data = null;
+                       try {
+                               data = CacheProvider.get().getBytes(zKey);
+                       } catch (Exception ignore) {
+                       }
+                       if (data != null) {
+                               String encoded = JTools.byteVectorToString(data); // encoded = Base64(deflate(json))
+                               byte[] decoded = Base64.getDecoder().decode(encoded);
+                               String json;
+                               try {
+                                       json = new String(inflate(decoded), StandardCharsets.UTF_8);
+                               } catch (Exception ex2) {
+                                       json = JTools.byteVectorToString(decoded);
+                               }
+                               return createRecFromJson(json, null);
+                       }
+
+                       // 2) Intentar como "pack" (url-safe b64 + deflate)
+                       return createRecFromPack(zKey, null);
+               } catch (Exception e) {
+                       // 3) Fallback legacy: distintos decoders y sin compresión
+                       byte[] decoded;
+                       try {
+                               decoded = java.util.Base64.getUrlDecoder().decode(zKey);
+                       } catch (IllegalArgumentException ex) {
+                               decoded = java.util.Base64.getDecoder().decode(zKey);
+                       }
+                       String json;
+                       try {
+                               json = new String(inflate(decoded), StandardCharsets.UTF_8);
+                       } catch (Exception ex2) {
+                               json = JTools.byteVectorToString(decoded);
+                       }
+                       return createRecFromJson(json, null);
+               }
+       }
 
 	private boolean okFilter(JBaseRecord baseRec, String filter) throws Exception {
 		if (!(baseRec instanceof JRecord))
@@ -152,22 +188,36 @@ public class JWinPackager {
 		return encoded;
 	}
 
-	public String baseRecToJSON(JBaseRecord rec) throws Exception {
-		String key = rec.getUniqueId() + "_rec";
-		String cached = null;
-		try {
-			byte[] data = CacheProvider.get().getBytes(key);
-			if (data != null)
-				cached = JTools.byteVectorToString(data);
-		} catch (Exception ignore) {
-		}
-		if (cached != null)
-			return cached;
-		String json = serializeRecToJson(rec);
-		String encoded = Base64.getEncoder().encodeToString(deflate(json.getBytes(StandardCharsets.UTF_8)));
-		CacheProvider.get().putBytes(key, JTools.stringToByteArray(encoded), 0);
-		return encoded;
-	}
+       public String baseRecToJSON(JBaseRecord rec) throws Exception {
+               String key = rec.getUniqueId() + "_rec";
+
+               // 1) cache hit
+               String cached = null;
+               try {
+                       byte[] data = CacheProvider.get().getBytes(key);
+                       if (data != null)
+                               cached = JTools.byteVectorToString(data);
+               } catch (Exception ignore) {
+               }
+               if (cached != null)
+                       return cached;
+
+               // 2) Si ya estamos serializando este mismo rec, devolvemos SOLO referencia (evita recursión)
+               if (isSerializingKey(key)) {
+                       return key; // referencia; se resolverá por cache en el receptor (ver getRegisterObjectRecTemp)
+               }
+
+               markSerializingKey(key);
+               try {
+                       String json = serializeRecToJson(rec);
+                       String encoded = Base64.getEncoder()
+                                       .encodeToString(deflate(json.getBytes(StandardCharsets.UTF_8)));
+                       CacheProvider.get().putBytes(key, JTools.stringToByteArray(encoded), 0);
+                       return encoded;
+               } finally {
+                       unmarkSerializingKey(key);
+               }
+       }
 
 	private static String packJson(String json) throws Exception {
 		byte[] raw = JTools.stringToByteArray(json);


### PR DESCRIPTION
## Summary
- Guard recursive JWinPackager serialization with ThreadLocal tracking to avoid infinite loops.
- Cache-first resolution for record references and decode from cache before falling back to legacy formats.
- Register nested records as cache references in JWebRequest to prevent re-serialization during parent serialization.

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*

------
https://chatgpt.com/codex/tasks/task_e_689bf6e5c498833399190ece9d2f8c15