### PR TITLE
Refactor action serialization to use transient references

### DIFF
--- a/src/pss/core/win/actions/BizAction.java
+++ b/src/pss/core/win/actions/BizAction.java
@@ -37,7 +37,7 @@ import pss.www.platform.actions.JWebActionFactory;
  */
 public class BizAction extends JRecord {
 
-	private JBaseWin owner = null;
+        private transient JBaseWin owner = null;
 	public int pId = 0;
 	public String sOwner = null;
 	public JString pCompany = new JString();
@@ -355,8 +355,8 @@ public class BizAction extends JRecord {
 	public final static int DROP = 4;
 	public final static int REPORT = 5;
 
-	private JAct submit = null;
-	private transient JAct oActionAutorizada = null;
+        private transient JAct submit = null;
+        private transient JAct oActionAutorizada = null;
 
 	// private JAct oActionListener = null;
 

--- a/src/pss/core/win/submits/JAct.java
+++ b/src/pss/core/win/submits/JAct.java
@@ -40,10 +40,10 @@ public abstract class JAct implements Cloneable, Serializable {
 	private String sName;
 	private int actionId;
 	private String actionUniqueId;
-	private JMessageInfo message;
-	private JBaseWin result;
-	private BizAction actionSource;
-	private JAct actionNext = null;
+        private JMessageInfo message;
+        private transient JBaseWin result;
+        private BizAction actionSource;
+        private transient JAct actionNext = null;
 	private boolean web = false;
 	protected boolean historyAction = true;
 	protected boolean historyTarget = false;

--- a/src/pss/core/win/submits/JActChildForm.java
+++ b/src/pss/core/win/submits/JActChildForm.java
@@ -6,7 +6,7 @@ import pss.core.winUI.forms.JBaseForm;
 public class JActChildForm extends JActModify {
 	
 //private JBaseForm form;
-	JWin parent;
+        transient JWin parent;
 /**
  * 
  */

--- a/src/pss/core/win/submits/JActDrop.java
+++ b/src/pss/core/win/submits/JActDrop.java
@@ -15,10 +15,10 @@ public class JActDrop extends JAct {
 		super();
 	}
 
-	private JBaseWin oDropListener;
+        private transient JBaseWin oDropListener;
 
 
-	private JAct nextAction;
+        private transient JAct nextAction;
 	private boolean dropControlId;
 
 	public JActDrop(JBaseWin zResult, JBaseWin listener, int actionId) {

--- a/src/pss/core/win/submits/JActFieldSwapWins.java
+++ b/src/pss/core/win/submits/JActFieldSwapWins.java
@@ -11,8 +11,8 @@ public class JActFieldSwapWins extends JActWins {
 	}
 
 
-	JWins selecteds;
-	JWins options;
+        transient JWins selecteds;
+        transient JWins options;
 	String fieldKeySource;
 	String fieldKeyOptions;
  

--- a/src/pss/core/win/submits/JActFieldWins.java
+++ b/src/pss/core/win/submits/JActFieldWins.java
@@ -14,8 +14,8 @@ public class JActFieldWins extends JActWins {
 	}
 
 
-	JWin winSource;
-	String field;
+        transient JWin winSource;
+        String field;
   Class clase;
   
 

--- a/src/pss/core/win/submits/JActGroupSubmit.java
+++ b/src/pss/core/win/submits/JActGroupSubmit.java
@@ -9,7 +9,7 @@ public class JActGroupSubmit extends JAct {
 	}
 
 	
-	JAct actSubmit;
+        transient JAct actSubmit;
 	
 	public JActGroupSubmit(JWins zResult) {
 		super(zResult);

--- a/src/pss/core/win/submits/JActMultiSubmit.java
+++ b/src/pss/core/win/submits/JActMultiSubmit.java
@@ -17,8 +17,8 @@ public class JActMultiSubmit extends JAct {
 		super();
 	}
 
-	JList<JAct> actionsList = null; 
-	JAct nextAction=null;
+        transient JList<JAct> actionsList = null;
+        transient JAct nextAction=null;
 	
 	public JActMultiSubmit(JWins zResult) {
 		super(zResult, -1);

--- a/src/pss/www/platform/actions/JWebWinFactory.java
+++ b/src/pss/www/platform/actions/JWebWinFactory.java
@@ -750,37 +750,68 @@ public class JWebWinFactory {
 		if (id != null)
 			dict.put("i", id);
 
-		if (zAction.needsFullSerialization()) {
-			byte[] serialized = JTools.stringToByteVector(JWebActionFactory.getCurrentRequest().serializeObject(zAction));
-			dict.put("a", JWinPackager.b64url(JWinPackager.deflate(serialized)));
-		} else {
-			// pack in
-			// JWinPackager packer = new JWinPackager(null);
-			String idOwner = JWebActionFactory.getCurrentRequest().registerObjectObj(zAction.getObjOwner());
-			if (idOwner != null && !idOwner.isEmpty()) {
-				dict.put("o", idOwner);
-			}
-			dict.put("p", zAction.getForceProviderName());
+                if (zAction.needsFullSerialization()) {
+                        JBaseWin owner = zAction.getObjOwner();
+                        if (owner != null) {
+                                String idOwner = JWebActionFactory.getCurrentRequest().registerObjectObj(owner);
+                                if (idOwner != null && !idOwner.isEmpty()) {
+                                        dict.put("o", idOwner);
+                                }
+                        }
+                        if (zAction.hasSubmit()) {
+                                JAct submit = zAction.getObjSubmit();
+                                if (submit != null) {
+                                        String idSubmit = JWebActionFactory.getCurrentRequest().registerObjectObj(submit);
+                                        if (idSubmit != null && !idSubmit.isEmpty()) {
+                                                dict.put("s", idSubmit);
+                                        }
+                                }
+                        }
+                        byte[] serialized = JTools
+                                        .stringToByteVector(JWebActionFactory.getCurrentRequest().serializeObject(zAction));
+                        dict.put("a", JWinPackager.b64url(JWinPackager.deflate(serialized)));
+                } else {
+                        // pack in
+                        // JWinPackager packer = new JWinPackager(null);
+                        String idOwner = JWebActionFactory.getCurrentRequest().registerObjectObj(zAction.getObjOwner());
+                        if (idOwner != null && !idOwner.isEmpty()) {
+                                dict.put("o", idOwner);
+                        }
+                        dict.put("p", zAction.getForceProviderName());
 
-			if (zAction.hasSubmit()) {
-				JAct submit = zAction.getObjSubmit();
-				if (submit != null) {
-					dict.put("s", submit.serialize());
-				}
-			}
-		}
-		return JWebActionFactory.getCurrentRequest().serializeRegisterMapJSON(dict);
-	}
+                        if (zAction.hasSubmit()) {
+                                JAct submit = zAction.getObjSubmit();
+                                if (submit != null) {
+                                        dict.put("s", submit.serialize());
+                                }
+                        }
+                }
+                return JWebActionFactory.getCurrentRequest().serializeRegisterMapJSON(dict);
+        }
 
 	public BizAction convertURLToAction(String sAction) throws Exception {
 		Map<String, String> dict = JWebActionFactory.getCurrentRequest().deserializeRegisterMapJSON(sAction);
 		BizAction action;
 
-		if (dict.containsKey("ay") || dict.containsKey("action")) {
-			String data = dict.containsKey("a") ? dict.get("a") : dict.get("action");
-			byte[] bytes = dict.containsKey("a") ? JWinPackager.inflate(JWinPackager.b64urlDecode(data)) : Base64.getDecoder().decode(data);
-			action = (BizAction) JWebActionFactory.getCurrentRequest().deserializeObject(JTools.byteVectorToString(bytes));
-		} else {
+                if (dict.containsKey("ay") || dict.containsKey("action")) {
+                        String data = dict.containsKey("a") ? dict.get("a") : dict.get("action");
+                        byte[] bytes = dict.containsKey("a") ? JWinPackager.inflate(JWinPackager.b64urlDecode(data))
+                                        : Base64.getDecoder().decode(data);
+                        action = (BizAction) JWebActionFactory.getCurrentRequest()
+                                        .deserializeObject(JTools.byteVectorToString(bytes));
+
+                        String ownerKey = dict.get("o");
+                        if (ownerKey != null) {
+                                JBaseWin owner = (JBaseWin) JWebActionFactory.getCurrentRequest().getRegisterObject(ownerKey);
+                                action.setObjOwner(owner);
+                        }
+                        String submitKey = dict.get("s");
+                        if (submitKey != null) {
+                                JAct submit = (JAct) JWebActionFactory.getCurrentRequest().getRegisterObject(submitKey);
+                                if (submit != null)
+                                        action.setObjSubmit(submit);
+                        }
+                } else {
 
 			String ownerKey = dict.containsKey("o") ? dict.get("o") : dict.get("owner");
 			String id = dict.containsKey("i") ? dict.get("i") : dict.get("actionid");


### PR DESCRIPTION
## Summary
- Avoid direct serialization of window and action references in BizAction, JAct and related classes
- Register JBaseWin and JAct instances when converting actions to and from URLs

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*
- `javac -cp src src/pss/www/platform/actions/JWebWinFactory.java` *(fails: unmappable character for encoding UTF-8 and missing dependencies such as org.apache.commons.codec.net.URLCodec)*

------
https://chatgpt.com/codex/tasks/task_e_689c81f99530833393d896dad59d3fb6