### PR TITLE
Handle string filter map initialization in BizAction

### DIFF
--- a/src/pss/core/win/actions/BizAction.java
+++ b/src/pss/core/win/actions/BizAction.java
@@ -1023,6 +1023,18 @@ public class BizAction extends JRecord {
 		this.filterMap = null;
 	}
 
+	public void setFilterMap(String serialized) throws Exception {
+		if (serialized == null || serialized.isEmpty()) {
+			this.filterMap = null;
+		} else {
+			this.filterMap = JFilterMap.unserialize(serialized);
+		}
+	}
+
+	public void setFilterMap(JFilterMap map) {
+		this.filterMap = map;
+	}
+
 	public boolean hasBackAction() throws Exception {
 		return bBackAction;
 	}
@@ -1195,20 +1207,20 @@ public class BizAction extends JRecord {
 					map.put(key, "A:" + ((JAct) value).serialize());
 				} else if (value instanceof BizAction) {
 					map.put(key, "B:" + ((BizAction) value).serialize());
-                                } else if (value instanceof JBaseWin) {
-                                        String id = JWebActionFactory.getCurrentRequest().registerWinObjectObj((JBaseWin) value);
-                                        if (id != null && !id.isEmpty())
-                                                map.put(key, "W:" + id);
-                                } else if (value instanceof Serializable) {
-                                        if (value.getClass().isArray()) {
-                                                String id = JWebActionFactory.getCurrentRequest()
-                                                                .registerObjectObj((Serializable) value);
-                                                if (id != null && !id.isEmpty())
-                                                        map.put(key, "S:" + id);
-                                        } else {
-                                                map.put(key, "V:" + serializeValue((Serializable) value));
-                                        }
-                                }
+	                        } else if (value instanceof JBaseWin) {
+	                                String id = JWebActionFactory.getCurrentRequest().registerWinObjectObj((JBaseWin) value);
+	                                if (id != null && !id.isEmpty())
+	                                        map.put(key, "W:" + id);
+	                        } else if (value instanceof Serializable) {
+	                                if (value.getClass().isArray()) {
+	                                        String id = JWebActionFactory.getCurrentRequest()
+	                                                        .registerObjectObj((Serializable) value);
+	                                        if (id != null && !id.isEmpty())
+	                                                map.put(key, "S:" + id);
+	                                } else {
+	                                        map.put(key, "V:" + serializeValue((Serializable) value));
+	                                }
+	                        }
 			}
 			clazz = clazz.getSuperclass();
 		}


### PR DESCRIPTION
## Summary
- allow BizAction to accept serialized filterMap strings and deserialize into JFilterMap
- expose a setter for assigning a JFilterMap instance directly

## Testing
- `javac -encoding cp1252 -cp src -d /tmp/bin src/pss/core/win/actions/BizAction.java` *(fails: unclosed character literals in unrelated sources)*

------
https://chatgpt.com/codex/tasks/task_e_689cf73840288333bf4d1c1ca6ce0627