### PR TITLE
feat: omit null entries in JWinPackager JSON

### DIFF
--- a/src/pss/www/platform/actions/JWinPackager.java
+++ b/src/pss/www/platform/actions/JWinPackager.java
@@ -15,6 +15,8 @@ import java.util.zip.Deflater;
 import java.util.zip.Inflater;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 import pss.core.data.interfaces.structure.RFilter;
 import pss.core.services.fields.JObject;
@@ -36,8 +38,10 @@ import pss.www.platform.cache.CacheProvider;
 public class JWinPackager {
 
 
-	private final JWebWinFactory factory;
-	private final ObjectMapper objectMapper = new ObjectMapper();
+        private final JWebWinFactory factory;
+        private final ObjectMapper objectMapper = new ObjectMapper()
+                        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                        .configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
 
 	public static String b64url(byte[] data) {
 		return Base64.getUrlEncoder().withoutPadding().encodeToString(data);


### PR DESCRIPTION
## Summary
- configure `JWinPackager` serializer to ignore `null` fields and map entries

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bfb659408333878417f2ccfe911c