### PR TITLE
feat: add query options and cursor tracking

### DIFF
--- a/src/pss/core/data/interfaces/sentences/BasicPlanAnalyzer.java
+++ b/src/pss/core/data/interfaces/sentences/BasicPlanAnalyzer.java
@@ -1,0 +1,12 @@
+package pss.core.data.interfaces.sentences;
+
+import java.sql.Connection;
+
+public class BasicPlanAnalyzer implements PlanAnalyzer {
+        @Override
+        public PlanInfo analyze(Connection c, String sql, JRegJDBC.Dialect d) throws Exception {
+                PlanInfo p = new PlanInfo();
+                p.rawPlanText = "";
+                return p;
+        }
+}

--- a/src/pss/core/data/interfaces/sentences/JRegJDBC.java
+++ b/src/pss/core/data/interfaces/sentences/JRegJDBC.java
@@ -19,13 +19,45 @@ import pss.core.tools.collections.JIterator;
 import pss.core.tools.collections.JList;
 
 /**
- * CJG - Comenté los métodos GetBase y SetBase porque estaban sobreescritos en
+ * CJG - ComentÃ© los mÃ©todos GetBase y SetBase porque estaban sobreescritos en
  * JBaseRegistro
  * 
  * @version 1.0
  */
 
 public class JRegJDBC extends JRegSQL {
+
+        public static enum QueryMode { PREVIEW, FULL, EXPLAIN_ONLY }
+
+        public static enum Dialect { POSTGRES, ORACLE, SQLSERVER, HIBERNATE }
+
+        public static final class RegQueryOptions {
+                public final QueryMode mode;
+                public final int previewRows;
+                public final Integer samplePercent;
+                public final int hardTimeoutSec;
+                public final int fetchSize;
+                public final Dialect dialect;
+                public final boolean runPlanGuard;
+
+                public RegQueryOptions(QueryMode m, int n, Integer sp, int to, int fs, Dialect d, boolean guard) {
+                        this.mode = m;
+                        this.previewRows = n;
+                        this.samplePercent = sp;
+                        this.hardTimeoutSec = to;
+                        this.fetchSize = fs;
+                        this.dialect = d;
+                        this.runPlanGuard = guard;
+                }
+
+                public static RegQueryOptions fullDefaults(Dialect d) {
+                        return new RegQueryOptions(QueryMode.FULL, 0, null, 60, 5000, d, true);
+                }
+
+                public static RegQueryOptions previewDefaults(Dialect d) {
+                        return new RegQueryOptions(QueryMode.PREVIEW, 200, 1, 5, 2000, d, true);
+                }
+        }
 
 	protected ResultSet oResultSet;
 	protected Object oObject;
@@ -116,7 +148,7 @@ public class JRegJDBC extends JRegSQL {
 	/**
 	 * Ejecuta una sentencia SELECT
 	 * 
-	 * @throw JConnectionBroken En caso que no haya conexión con la base
+	 * @throw JConnectionBroken En caso que no haya conexiÃ³n con la base
 	 */
 	protected Statement getQueryOpenStatement(JBaseJDBC oDatabaseImpl) throws Exception {
 		return null;
@@ -141,12 +173,12 @@ public class JRegJDBC extends JRegSQL {
 	/**
 	 * Ejecuta una sentencia UPDATE, DELETE, INSERT, etc.
 	 * 
-	 * @throw JConnectionBroken En caso que no haya conexión con la base
+	 * @throw JConnectionBroken En caso que no haya conexiÃ³n con la base
 	 */
 	@Override
 	protected int QueryExec() throws Exception {
 		if (!this.getBaseJDBC().isTransactionInProgress()) {
-			JExcepcion.SendError("Sentencia fuera de transacción");
+			JExcepcion.SendError("Sentencia fuera de transacciÃ³n");
 		}
 		return executeStatementWithResult(sSQL);
 	}
@@ -397,29 +429,37 @@ public class JRegJDBC extends JRegSQL {
 	}
 
 	/**
-	 * Obtiene una nueva Statement luego de intentar una nueva conexión con la Base
+	 * Obtiene una nueva Statement luego de intentar una nueva conexiÃ³n con la Base
 	 * de datos.
 	 * 
 	 * @return la statement nueva
-	 * @throw JConnectionBroken si no pudo establecer una nueva conexión
+	 * @throw JConnectionBroken si no pudo establecer una nueva conexiÃ³n
 	 */
 	/*
 	 * private Statement getNewStatement() throws Exception { if
 	 * (!JBDatos.retryEstablishConnection()) { throw new
-	 * JConnectionBroken("No se puede reestablecer la conexión"); } return
+	 * JConnectionBroken("No se puede reestablecer la conexiÃ³n"); } return
 	 * getBaseJDBC().GetConnection().createStatement(); }
 	 */
 	public JBaseJDBC getBaseJDBC() {
 		return (JBaseJDBC) this.getDatabase();
 	}
 
-	public JIterator<String> getFieldNameIterator() throws Exception {
-		JList<String> vItems;
-		vItems = JCollectionFactory.createList();
-		for (int i = 1; i <= oResultSet.getMetaData().getColumnCount(); i++) {
-			vItems.addElement(oResultSet.getMetaData().getColumnName(i));
-		}
-		return vItems.getIterator();
-	}
+        public JIterator<String> getFieldNameIterator() throws Exception {
+                JList<String> vItems;
+                vItems = JCollectionFactory.createList();
+                for (int i = 1; i <= oResultSet.getMetaData().getColumnCount(); i++) {
+                        vItems.addElement(oResultSet.getMetaData().getColumnName(i));
+                }
+                return vItems.getIterator();
+        }
+
+        public QueryResult query(String sql) throws Exception {
+                return query(sql, RegQueryOptions.fullDefaults(Dialect.POSTGRES));
+        }
+
+        public QueryResult query(String sql, RegQueryOptions opts) throws Exception {
+                throw new UnsupportedOperationException("Not implemented");
+        }
 
 }

--- a/src/pss/core/data/interfaces/sentences/PlanAnalyzer.java
+++ b/src/pss/core/data/interfaces/sentences/PlanAnalyzer.java
@@ -1,0 +1,9 @@
+package pss.core.data.interfaces.sentences;
+
+import java.sql.Connection;
+
+import pss.core.data.interfaces.sentences.JRegJDBC.Dialect;
+
+public interface PlanAnalyzer {
+        PlanInfo analyze(Connection c, String sql, Dialect d) throws Exception;
+}

--- a/src/pss/core/data/interfaces/sentences/PlanInfo.java
+++ b/src/pss/core/data/interfaces/sentences/PlanInfo.java
@@ -1,0 +1,9 @@
+package pss.core.data.interfaces.sentences;
+
+public final class PlanInfo {
+        public long estRows;
+        public double totalCost;
+        public boolean hasSeqScanOnBigTable;
+        public boolean hasCartesianJoin;
+        public String rawPlanText;
+}

--- a/src/pss/core/data/interfaces/sentences/QueryGuard.java
+++ b/src/pss/core/data/interfaces/sentences/QueryGuard.java
@@ -1,0 +1,19 @@
+package pss.core.data.interfaces.sentences;
+
+public final class QueryGuard {
+        public enum Decision { OK, WARN, BLOCK }
+
+        public Decision decide(PlanInfo p) {
+                if (p == null)
+                        return Decision.OK;
+                if (p.hasCartesianJoin)
+                        return Decision.BLOCK;
+                if (p.hasSeqScanOnBigTable && p.estRows > 1_000_000)
+                        return Decision.BLOCK;
+                if (p.totalCost > 50_000_000)
+                        return Decision.BLOCK;
+                if (p.estRows > 1_000_000)
+                        return Decision.WARN;
+                return Decision.OK;
+        }
+}

--- a/src/pss/core/data/interfaces/sentences/QueryResult.java
+++ b/src/pss/core/data/interfaces/sentences/QueryResult.java
@@ -1,0 +1,19 @@
+package pss.core.data.interfaces.sentences;
+
+public class QueryResult {
+        public final boolean blocked;
+        public final String rawPlanText;
+        public final int rowCount;
+        public final boolean truncated;
+
+        public QueryResult(boolean blocked, String rawPlanText, int rowCount, boolean truncated) {
+                this.blocked = blocked;
+                this.rawPlanText = rawPlanText;
+                this.rowCount = rowCount;
+                this.truncated = truncated;
+        }
+
+        public static QueryResult blocked(String msg, String plan) {
+                return new QueryResult(true, plan, 0, false);
+        }
+}


### PR DESCRIPTION
## Summary
- track active cursors outside transactions and improve cancel logic
- add RegQueryOptions and query overloads with default modes
- scaffold dialect-aware query execution and plan guard utilities

## Testing
- `javac -cp src src/pss/core/data/interfaces/connections/JBaseJDBC.java`
- `javac -cp src src/pss/core/data/interfaces/sentences/JRegJDBC.java`


------
https://chatgpt.com/codex/tasks/task_e_68a519f7d7e88333a63a05596f3c10f0