### PR TITLE
Refactor report generation to use internal renderer

### DIFF
--- a/src/pss/report/ReportController.java
+++ b/src/pss/report/ReportController.java
@@ -1,13 +1,15 @@
 package pss.report;
 
+import java.util.HashMap;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletResponse;
+import pss.core.services.records.JFilterMap;
+import pss.core.tools.collections.JIterator;
 
 /**
- * Example controller showcasing how to use {@link InternalReportService} and
- * {@link ReportRenderer} to deliver HTML or PDF reports without performing
- * internal HTTP requests.
+ * Controller-like facade used to render reports without making internal HTTP
+ * calls. It relies on {@link InternalReportService} to build the report's
+ * HTML and on {@link ReportRenderer} to optionally convert it to PDF.
  */
 public class ReportController {
 
@@ -19,21 +21,51 @@ public class ReportController {
         this.renderer = renderer;
     }
 
-    public void getHtmlView(String reportName,
-                            String xslVariant,
-                            boolean pdf,
-                            UserContext user,
-                            Map<String, Object> params,
-                            HttpServletResponse resp) throws Exception {
-
-        HtmlPayload payload = reportService.buildHtml(reportName, xslVariant, user, params);
-
-        if (!pdf) {
-            resp.setContentType("text/html; charset=UTF-8");
-            resp.getWriter().write(renderer.renderHtml(payload));
-        } else {
-            resp.setContentType("application/pdf");
-            resp.getOutputStream().write(renderer.renderPdf(payload));
+    private Map<String, Object> toMap(JFilterMap params) throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        if (params != null && params.getMap() != null) {
+            JIterator<String> it = params.getMap().getKeyIterator();
+            while (it.hasMoreElements()) {
+                String key = it.nextElement();
+                map.put(key, params.getMap().getElement(key));
+            }
         }
+        return map;
+    }
+
+    private UserContext buildUserContext() throws Exception {
+        return UserContext.fromCurrentUser();
+    }
+
+    /**
+     * Builds and returns the HTML representation of the given report.
+     */
+    public String getHtmlView(String reportName, String xslVariant, JFilterMap params) throws Exception {
+        HtmlPayload payload = reportService.buildHtml(reportName, xslVariant, buildUserContext(), toMap(params));
+        return renderer.renderHtml(payload);
+    }
+
+    /**
+     * Generates a PDF for the given report and returns it as a byte array.
+     */
+    public byte[] getPdfBytes(String reportName, String xslVariant, JFilterMap params) throws Exception {
+        HtmlPayload payload = reportService.buildHtml(reportName, xslVariant, buildUserContext(), toMap(params));
+        return renderer.renderPdf(payload);
+    }
+
+    /**
+     * Returns the CSV output for the report using a dedicated XSLT variant.
+     */
+    public String getCsvView(String reportName, JFilterMap params) throws Exception {
+        HtmlPayload payload = reportService.buildHtml(reportName, "csv", buildUserContext(), toMap(params));
+        return payload.getHtml();
+    }
+
+    /**
+     * Returns the Excel output for the report using a dedicated XSLT variant.
+     */
+    public String getExcelView(String reportName, JFilterMap params) throws Exception {
+        HtmlPayload payload = reportService.buildHtml(reportName, "excel", buildUserContext(), toMap(params));
+        return payload.getHtml();
     }
 }

--- a/src/pss/report/UserContext.java
+++ b/src/pss/report/UserContext.java
@@ -3,21 +3,32 @@ package pss.report;
 import pss.common.security.BizUsuario;
 
 /**
- * Wrapper around {@link BizUsuario} exposing only the information required for
- * report generation.
+ * Minimal information required for report generation. Instances are created
+ * from the current {@link BizUsuario} using its certificate and login name.
  */
 public final class UserContext {
-    private final BizUsuario usuario;
+    private final String certificado;
+    private final String login;
 
-    public UserContext(BizUsuario usuario) {
-        this.usuario = usuario;
+    public UserContext(String certificado, String login) {
+        this.certificado = certificado;
+        this.login = login;
     }
 
-    public BizUsuario getUsuario() {
-        return usuario;
+    public String getCertificado() {
+        return certificado;
     }
 
-    public String getLogin() throws Exception {
-        return usuario.getUsuario();
+    public String getLogin() {
+        return login;
+    }
+
+    /**
+     * Convenience factory creating the context for the currently authenticated
+     * user.
+     */
+    public static UserContext fromCurrentUser() throws Exception {
+        BizUsuario usr = BizUsuario.getUsr();
+        return new UserContext(usr.GetCertificado(), usr.getUsuario());
     }
 }


### PR DESCRIPTION
## Summary
- Reworked report `UserContext` to carry certificate and login, with factory method to create from current user.
- Added a new `ReportController` facade that uses `InternalReportService` and `ReportRenderer` to build HTML, PDF, CSV and Excel outputs in-memory.
- Updated `JBaseWin#getHtmlView` to invoke the new in-memory rendering, with helpers for PDF, CSV and Excel.

## Testing
- `javac -cp src $(find src/pss/report -name '*.java') src/pss/core/win/JBaseWin.java` *(fails: package com.lowagie.text does not exist; numerous unmappable character errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8794d20208333b6819cef605c5356