### PR TITLE
feat: emulate cocoon pipeline in process

### DIFF
--- a/src/pss/common/report/CocoonSerializer.java
+++ b/src/pss/common/report/CocoonSerializer.java
@@ -1,0 +1,64 @@
+package pss.common.report;
+
+/**
+ * Enumeration of the serializers that were originally defined in the Cocoon
+ * sitemap. Each serializer declares its mime type, the character encoding used
+ * and whether the output should be compressed using GZIP.
+ */
+public enum CocoonSerializer {
+
+    XML("xml", "text/xml", "UTF-8", false),
+    HTML("html", "text/html", "UTF-8", true),
+    HTML_DECODED("html-decoded", "text/html", "ISO-8859-5", true),
+    HTML_NOCOMPRESS("html-nocompress", "text/html", "ISO-8859-5", false),
+    GRAPH("graph", "text/html", "UTF-8", true),
+    MAP("map", "text/html", "UTF-8", true),
+    EXCEL("excel", "application/vnd.ms-excel", "UTF-8", false),
+    NONE("none", "application/vnd.ms-excel", "UTF-8", false),
+    JSON("json", "application/json", "UTF-8", false),
+    JSON_COMPRESS("json-compress", "application/json", "UTF-8", true),
+    MOBILE("mobile", "application/json", "UTF-8", true),
+    CSV("csv", "text/csv", "UTF-8", false),
+    JS("js", "text/javascript", "UTF-8", false),
+    CSS("css", "text/css", "UTF-8", false);
+
+    private final String name;
+    private final String mimeType;
+    private final String encoding;
+    private final boolean gzip;
+
+    CocoonSerializer(String name, String mimeType, String encoding, boolean gzip) {
+        this.name = name;
+        this.mimeType = mimeType;
+        this.encoding = encoding;
+        this.gzip = gzip;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public boolean isGzip() {
+        return gzip;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Resolves the serializer by its sitemap name.
+     */
+    public static CocoonSerializer from(String name) {
+        for (CocoonSerializer s : values()) {
+            if (s.name.equalsIgnoreCase(name)) {
+                return s;
+            }
+        }
+        throw new IllegalArgumentException("Unknown serializer: " + name);
+    }
+}

--- a/src/pss/common/report/InternalRequestResolverEmu.java
+++ b/src/pss/common/report/InternalRequestResolverEmu.java
@@ -1,0 +1,58 @@
+package pss.common.report;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Replaces the old Cocoon pipeline composed by the act/transform/select steps
+ * of the sitemap. It resolves reports entirely in memory.
+ */
+public class InternalRequestResolverEmu {
+
+    private final InternalReportService reportService = new InternalReportService();
+    private final ReportRenderer renderer = new ReportRenderer();
+
+    public HtmlPayload resolveHtml(String reportName,
+                                   String serializerName,
+                                   String transformerOpt,
+                                   String basedir,
+                                   String dictionary,
+                                   String requestid,
+                                   UserContext user,
+                                   Map<String, Object> filters) throws Exception {
+
+        // Validate that the serializer exists even if we only use HTML-like ones
+        CocoonSerializer.from(serializerName);
+
+        String xslVariant = "html";
+        if ("htmlfull".equalsIgnoreCase(serializerName)) {
+            xslVariant = "htmlfull";
+        } else if ("graph".equalsIgnoreCase(serializerName)) {
+            xslVariant = "graph";
+        } else if ("map".equalsIgnoreCase(serializerName)) {
+            xslVariant = "map";
+        }
+
+        Map<String, Object> xsltParams = new HashMap<>();
+        if (basedir != null) xsltParams.put("basedir", basedir);
+        if (dictionary != null) xsltParams.put("dictionary", dictionary);
+        if (requestid != null) xsltParams.put("requestid", requestid);
+
+        return reportService.buildHtml(reportName, xslVariant, user, filters,
+                xsltParams, transformerOpt);
+    }
+
+    public byte[] resolvePdf(String reportName,
+                              String serializerName,
+                              String transformerOpt,
+                              String basedir,
+                              String dictionary,
+                              String requestid,
+                              UserContext user,
+                              Map<String, Object> filters) throws Exception {
+        String htmlVariant = "htmlfull".equalsIgnoreCase(serializerName) ? "htmlfull" : "html";
+        HtmlPayload payload = resolveHtml(reportName, htmlVariant, transformerOpt,
+                basedir, dictionary, requestid, user, filters);
+        return renderer.renderPdf(payload);
+    }
+}

--- a/src/pss/common/report/SerializerDispatcher.java
+++ b/src/pss/common/report/SerializerDispatcher.java
@@ -1,0 +1,78 @@
+package pss.common.report;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.zip.GZIPOutputStream;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+
+/**
+ * Utility that writes different serializer outputs emulating Cocoon's
+ * <map:serializer> step. It works entirely in memory and writes the result to
+ * the provided {@link HttpServletResponse}.
+ */
+public class SerializerDispatcher {
+
+    private final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+
+    public void write(HttpServletResponse resp,
+                      CocoonSerializer type,
+                      HtmlPayload htmlPayload,
+                      String textBodyOpt,
+                      Document xmlOpt) throws IOException, TransformerException {
+
+        resp.setCharacterEncoding(type.getEncoding());
+        resp.setContentType(type.getMimeType());
+
+        byte[] body;
+        switch (type) {
+            case XML:
+                body = serializeXml(xmlOpt, type.getEncoding());
+                break;
+            case HTML:
+            case HTML_DECODED:
+            case HTML_NOCOMPRESS:
+            case GRAPH:
+            case MAP:
+                body = toBytes(htmlPayload.getHtml(), type.getEncoding());
+                break;
+            default:
+                body = toBytes(textBodyOpt == null ? "" : textBodyOpt, type.getEncoding());
+                break;
+        }
+
+        if (type.isGzip()) {
+            resp.setHeader("Content-Encoding", "gzip");
+            try (GZIPOutputStream gzip = new GZIPOutputStream(resp.getOutputStream())) {
+                gzip.write(body);
+            }
+        } else {
+            resp.setContentLength(body.length);
+            OutputStream os = resp.getOutputStream();
+            os.write(body);
+            os.flush();
+        }
+    }
+
+    private byte[] toBytes(String text, String encoding) {
+        return text.getBytes(Charset.forName(encoding));
+    }
+
+    private byte[] serializeXml(Document doc, String encoding) throws TransformerException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Transformer transformer = transformerFactory.newTransformer();
+        transformer.setOutputProperty(OutputKeys.ENCODING, encoding);
+        transformer.transform(new DOMSource(doc), new StreamResult(baos));
+        return baos.toByteArray();
+    }
+}

--- a/src/pss/common/report/UserContext.java
+++ b/src/pss/common/report/UserContext.java
@@ -3,24 +3,32 @@ package pss.common.report;
 import pss.common.security.BizUsuario;
 
 /**
- * Wrapper around {@link BizUsuario} exposing only the information required for
- * report generation.
+ * Wrapper exposing only the information required for report generation.
  */
 public final class UserContext {
-  
-  
-    public static BizUsuario getUsuario() throws Exception {
-        return BizUsuario.getUsr();
+
+    private final String userId;
+
+    private UserContext(String userId) {
+        this.userId = userId;
     }
- 
 
-  /**
-   * Convenience factory creating the context for the currently authenticated
-   * user.
-   */
-  public static UserContext fromCurrentUser() throws Exception {
-      return new UserContext();
-  }
+    public String getUserId() {
+        return userId;
+    }
+
+    /**
+     * Creates a context from the given {@link BizUsuario}.
+     */
+    public static UserContext from(BizUsuario usr) throws Exception {
+        return new UserContext(usr.GetCertificado());
+    }
+
+    /**
+     * Convenience factory creating the context for the currently authenticated
+     * user.
+     */
+    public static UserContext fromCurrentUser() throws Exception {
+        return from(BizUsuario.getUsr());
+    }
 }
-
- 


### PR DESCRIPTION
## Summary
- add `CocoonSerializer` enum capturing MIME types, encodings and gzip support
- provide `SerializerDispatcher` to emit in-memory serialized responses
- enhance `InternalReportService` for extra XSLT parameters and transformer override
- create `InternalRequestResolverEmu` and expand `UserContext`
- update `JBaseWin` to resolve reports without HTTP round-trip

## Testing
- `javac -cp src src/pss/common/report/CocoonSerializer.java`
- `javac -cp src src/pss/common/report/SerializerDispatcher.java` *(fails: package javax.servlet.http does not exist)*
- `javac -cp src src/pss/common/report/InternalReportService.java` *(fails: unmappable character for encoding UTF-8)*


------
https://chatgpt.com/codex/tasks/task_e_68a8a68575ec833394b71fb2814f994a