### PR TITLE
Enhance report resolver for Excel and CSV

### DIFF
--- a/src/pss/common/report/InternalRequestResolverEmu.java
+++ b/src/pss/common/report/InternalRequestResolverEmu.java
@@ -1,5 +1,6 @@
 package pss.common.report;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,11 +34,7 @@ public class InternalRequestResolverEmu {
             xslVariant = "map";
         }
 
-        Map<String, Object> xsltParams = new HashMap<>();
-        if (basedir != null) xsltParams.put("basedir", basedir);
-        if (dictionary != null) xsltParams.put("dictionary", dictionary);
-        if (requestid != null) xsltParams.put("requestid", requestid);
-
+        Map<String, Object> xsltParams = buildXsltParams(basedir, dictionary, requestid);
         return reportService.buildHtml(reportName, xslVariant, user, filters,
                 xsltParams, transformerOpt);
     }
@@ -54,5 +51,58 @@ public class InternalRequestResolverEmu {
         HtmlPayload payload = resolveHtml(reportName, htmlVariant, transformerOpt,
                 basedir, dictionary, requestid, user, filters);
         return renderer.renderPdf(payload);
+    }
+
+    public byte[] resolveExcel(String reportName,
+                               String transformerOpt,
+                               String basedir,
+                               String dictionary,
+                               String requestid,
+                               UserContext user,
+                               Map<String, Object> filters) throws Exception {
+        Map<String, Object> xsltParams = buildXsltParams(basedir, dictionary, requestid);
+        HtmlPayload payload = reportService.buildHtml(reportName, "excel", user, filters,
+                xsltParams, transformerOpt);
+        return payload.getHtml().getBytes(StandardCharsets.UTF_8);
+    }
+
+    public byte[] resolveCsv(String reportName,
+                             String transformerOpt,
+                             String basedir,
+                             String dictionary,
+                             String requestid,
+                             UserContext user,
+                             Map<String, Object> filters) throws Exception {
+        Map<String, Object> xsltParams = buildXsltParams(basedir, dictionary, requestid);
+        HtmlPayload payload = reportService.buildHtml(reportName, "csv", user, filters,
+                xsltParams, transformerOpt);
+        return payload.getHtml().getBytes(StandardCharsets.UTF_8);
+    }
+
+    public String resolveJson(String reportName,
+                              String transformerOpt,
+                              String basedir,
+                              String dictionary,
+                              String requestid,
+                              UserContext user,
+                              Map<String, Object> filters) throws Exception {
+        Map<String, Object> xsltParams = buildXsltParams(basedir, dictionary, requestid);
+        HtmlPayload payload = reportService.buildHtml(reportName, "json", user, filters,
+                xsltParams, transformerOpt);
+        return payload.getHtml();
+    }
+
+    private Map<String, Object> buildXsltParams(String basedir, String dictionary, String requestid) {
+        Map<String, Object> xsltParams = new HashMap<>();
+        if (basedir != null) {
+            xsltParams.put("basedir", basedir);
+        }
+        if (dictionary != null) {
+            xsltParams.put("dictionary", dictionary);
+        }
+        if (requestid != null) {
+            xsltParams.put("requestid", requestid);
+        }
+        return xsltParams;
     }
 }

--- a/src/pss/core/win/JBaseWin.java
+++ b/src/pss/core/win/JBaseWin.java
@@ -4,13 +4,13 @@ import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
 import pss.common.layout.JWinLayout;
 import pss.common.report.HtmlPayload;
-import pss.common.report.InternalReportService;
 import pss.common.report.InternalRequestResolverEmu;
 import pss.common.report.ReportRenderer;
 import pss.common.report.UserContext;
@@ -1370,34 +1370,28 @@ public abstract class JBaseWin implements IInMemory, Transferable, Serializable 
                 return resolver.resolvePdf("win_list_x", builderArguments, null, basedir, null, null, user, filters);
         }
 
-	public String getCsvView(int action, JFilterMap params) throws Exception {
-		Map<String, Object> map = new HashMap<>();
-		if (params != null && params.getMap() != null) {
-			JIterator<String> it = params.getMap().getKeyIterator();
-			while (it.hasMoreElements()) {
-				String key = it.nextElement();
-				map.put(key, params.getMap().getElement(key));
-			}
-		}
+        public String getCsvView(int action, JFilterMap params) throws Exception {
+                Map<String, Object> map = toMap(params);
+                map.put("action", action);
 
-		InternalReportService service = new InternalReportService();
-		HtmlPayload payload = service.buildHtml(getClass().getSimpleName(), "csv", UserContext.fromCurrentUser(), map);
-		return payload.getHtml();
-	}
+                UserContext user = UserContext.from(BizUsuario.getUsr());
+                String basedir = BizPssConfig.getPssConfig().getAppURLPreview();
+
+                InternalRequestResolverEmu resolver = new InternalRequestResolverEmu();
+                byte[] bytes = resolver.resolveCsv("win_list_x", null, basedir, null, null, user, map);
+                return new String(bytes, StandardCharsets.UTF_8);
+        }
 
         public String getExcelView(int action, JFilterMap params) throws Exception {
-                Map<String, Object> map = new HashMap<>();
-                if (params != null && params.getMap() != null) {
-                        JIterator<String> it = params.getMap().getKeyIterator();
-                        while (it.hasMoreElements()) {
-                                String key = it.nextElement();
-                                map.put(key, params.getMap().getElement(key));
-                        }
-                }
+                Map<String, Object> map = toMap(params);
+                map.put("action", action);
 
-                InternalReportService service = new InternalReportService();
-                HtmlPayload payload = service.buildHtml(getClass().getSimpleName(), "excel", UserContext.fromCurrentUser(), map);
-                return payload.getHtml();
+                UserContext user = UserContext.from(BizUsuario.getUsr());
+                String basedir = BizPssConfig.getPssConfig().getAppURLPreview();
+
+                InternalRequestResolverEmu resolver = new InternalRequestResolverEmu();
+                byte[] bytes = resolver.resolveExcel("win_list_x", null, basedir, null, null, user, map);
+                return new String(bytes, StandardCharsets.UTF_8);
         }
 
         private Map<String, Object> toMap(JFilterMap params) {


### PR DESCRIPTION
## Summary
- extend `InternalRequestResolverEmu` with helpers for Excel, CSV and JSON pipelines
- route `JBaseWin` CSV/Excel generation through the resolver and enforce UTF-8 output

## Testing
- `javac -cp src @report_sources.txt` *(fails: package org.xhtmlrenderer.pdf does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b1a1c7c8833395096f85d4277d7a