### PR TITLE
feat: support owner-aware report generation

### DIFF
--- a/src/pss/www/platform/content/generators/internal/InternalReportService.java
+++ b/src/pss/www/platform/content/generators/internal/InternalReportService.java
@@ -15,9 +15,11 @@ import javax.xml.transform.stream.StreamSource;
 import org.w3c.dom.Document;
 
 import pss.common.security.BizUsuario;
+import pss.core.win.JBaseWin;
 import pss.core.win.actions.BizAction;
 import pss.www.platform.actions.JWebActionFactory;
 import pss.www.platform.actions.JWebRequest;
+import pss.www.platform.actions.resolvers.JDoInternalRequestResolver;
 import pss.www.platform.content.generators.InMemoryGenerator;
 import pss.www.platform.content.generators.JBasicXMLContentGenerator;
 import pss.www.platform.content.generators.JXMLContent;
@@ -32,9 +34,9 @@ public class InternalReportService {
 
 	private final TransformerFactory factory = TransformerFactory.newInstance();
 
-	public HtmlPayload buildHtml(String reportName, String xslVariant, UserContext userContext, Map<String, Object> businessParams, Map<String, Object> xsltParams, String transformerOverrideOpt) throws Exception {
+        public HtmlPayload buildHtml(String reportName, String xslVariant, UserContext userContext, Map<String, Object> businessParams, Map<String, Object> xsltParams, String transformerOverrideOpt) throws Exception {
 
-		Document xml = buildXml(reportName, businessParams, userContext);
+                Document xml = buildXml(reportName, businessParams, userContext);
 
 		String xslPath;
 		if (transformerOverrideOpt != null) {
@@ -64,8 +66,46 @@ public class InternalReportService {
 	}
 
 	public HtmlPayload buildHtml(String reportName, String xslVariant, UserContext userContext, Map<String, Object> params) throws Exception {
-		return buildHtml(reportName, xslVariant, userContext, params, null, null);
-	}
+                return buildHtml(reportName, xslVariant, userContext, params, null, null);
+        }
+
+        public HtmlPayload buildHtmlForOwner(
+                JBaseWin owner,
+                String reportName,
+                String xslVariant,
+                UserContext userContext,
+                Map<String, Object> businessParams,
+                Map<String, Object> xsltParams,
+                String transformerOverrideOpt) throws Exception {
+
+                Document xml = buildXmlForOwner(owner, reportName, businessParams, userContext);
+
+                String xslPath;
+                if (transformerOverrideOpt != null) {
+                        if (transformerOverrideOpt.startsWith("/")) {
+                                xslPath = transformerOverrideOpt;
+                        } else {
+                                xslPath = "/xsl/" + transformerOverrideOpt;
+                        }
+                } else {
+                        xslPath = "/xsl/" + reportName + '_' + xslVariant + ".xsl";
+                }
+                Source xsl = new StreamSource(getClass().getResourceAsStream(xslPath));
+
+                Transformer transformer = factory.newTransformer(xsl);
+                transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+                if (xsltParams != null) {
+                        for (Map.Entry<String, Object> e : xsltParams.entrySet()) {
+                                transformer.setParameter(e.getKey(), e.getValue());
+                        }
+                }
+
+                StringWriter writer = new StringWriter();
+                transformer.transform(new DOMSource(xml), new StreamResult(writer));
+
+                String baseUrl = getClass().getResource("/public/").toExternalForm();
+                return new HtmlPayload(writer.toString(), baseUrl);
+        }
 
 	/**
 	 * Builds the report XML by executing the same in-memory pipeline used by the
@@ -75,7 +115,7 @@ public class InternalReportService {
 	 * {@link JWebWinMatrixResponsive} view associated to the report.
 	 */
 	@SuppressWarnings("unchecked")
-	private Document buildXml(String reportName, Map<String, Object> params, UserContext user) throws Exception {
+        private Document buildXml(String reportName, Map<String, Object> params, UserContext user) throws Exception {
 
 	    // ------------------------------------------------------------------
 	    // 0) Preconditions: request y usuario actual
@@ -171,8 +211,88 @@ public class InternalReportService {
 	    // ------------------------------------------------------------------
 	    // 3) Entregar el Document resultante
 	    // ------------------------------------------------------------------
-	    return extractDocument(zContent);
-	}
+            return extractDocument(zContent);
+        }
+
+        @SuppressWarnings("unchecked")
+        private Document buildXmlForOwner(JBaseWin owner, String reportName, Map<String, Object> params, UserContext user) throws Exception {
+
+            JWebRequest req = JWebActionFactory.getCurrentRequest();
+            if (req == null) throw new IllegalStateException("No current request available");
+            if (BizUsuario.getUsr() == null && user != null) {
+                // BizUsuario.setFromCertificado(user.getUserId());
+            }
+
+            final String serializer = "html";
+            String arguments;
+            if ("htmlfull".equalsIgnoreCase(String.valueOf(params.get("serializer")))) {
+                arguments = "dg_export=serializer=htmlfull,object=" + reportName + ",range=all,preserve=T,history=N"
+                          + "&dg_win_list_nav=name_op1=export,with_preview_op1=N,embedded_op1=false,toolbar_op1=none,&"
+                          + "&dg_client_conf=pw_op1=1000,ph_op1=2500,sw_op1=1000,sh_op1=2500";
+            } else {
+                arguments = "dg_export=serializer=" + serializer + ",object=" + reportName + ",range=all,preserve=T,history=N"
+                          + "&dg_win_list_nav=name_op1=export,with_preview_op1=N,embedded_op1=false,toolbar_op1=none,&"
+                          + "&dg_client_conf=pw_op1=1500,ph_op1=2500,sw_op1=1500,sh_op1=2500";
+            }
+
+            if (params != null) {
+                for (Map.Entry<String, Object> e : params.entrySet()) {
+                    if (e.getValue() == null) continue;
+                    String k = "dgf_filter_pane_fd-" + e.getKey();
+                    String v = String.valueOf(e.getValue());
+                    arguments += "&" + k + "=" + urlEncodeISO(v);
+                }
+            }
+
+            final String internalId = java.util.UUID.randomUUID().toString();
+            final int actionInt = params != null && params.get("action") != null
+                    ? Integer.parseInt(String.valueOf(params.get("action"))) : 0;
+
+            String extraArguments = JDoInternalRequestResolver.addInternaRequest(
+                    internalId,
+                    owner,
+                    actionInt,
+                    BizUsuario.getUsr() != null ? BizUsuario.getUsr().GetCertificado() : user.getUserId()
+            );
+
+            pushQueryParamsToRequest(req, arguments);
+            if (extraArguments != null && !extraArguments.isEmpty()) {
+                pushQueryParamsToRequest(req, extraArguments);
+            }
+
+            JXMLContent zContent = createContentWithOwnerContext(owner, req);
+
+            Object generator = new pss.www.platform.content.generators.JWinListInternalRequestPageGenerator();
+
+            boolean produced = false;
+            String[] methodCandidates = {
+                    "generate", "generateTo", "produce", "build", "componentToXML"
+            };
+            for (String m : methodCandidates) {
+                try {
+                    Method method = generator.getClass().getMethod(m, zContent.getClass());
+                    method.invoke(generator, zContent);
+                    produced = true;
+                    break;
+                } catch (NoSuchMethodException ignore) {
+                }
+            }
+
+            if (!produced) {
+                BizAction act = new BizAction();
+                act.pAccion.setValue(reportName);
+                JWebWinMatrixResponsive view = new JWebWinMatrixResponsive(act, true);
+                view.setEmbedded(true);
+                try {
+                    Method setOwner = view.getClass().getMethod("setOwner", JBaseWin.class);
+                    setOwner.invoke(view, owner);
+                } catch (NoSuchMethodException ignore) {
+                }
+                view.componentToXML(zContent);
+            }
+
+            return extractDocument(zContent);
+        }
 
 	/* ====================== Helpers ====================== */
 
@@ -195,19 +315,33 @@ public class InternalReportService {
 	    catch (Exception e) { return s; }
 	}
 
-	private static String urlDecodeISO(String s) {
-	    try { return new org.apache.commons.codec.net.URLCodec().decode(s, "ISO-8859-1"); }
-	    catch (Exception e) { return s; }
-	}
+        private static String urlDecodeISO(String s) {
+            try { return new org.apache.commons.codec.net.URLCodec().decode(s, "ISO-8859-1"); }
+            catch (Exception e) { return s; }
+        }
 
-	/**
-	 * Crea un JXMLContent “válido” para que .addProviderHistory / HistoryManager
-	 * y otros accesos a sesión no fallen durante la generación.
-	 */
-	private static JXMLContent createJXMLContentWithSessionContext(JWebRequest req) throws Exception {
-	    // Si tu proyecto tiene una factoría/constructor específico, usalo acá.
-	    // Muchas bases tienen JXMLContent(JWebRequest) o con un “generator ctx”.
-	    try {
+        /**
+         * Crea un JXMLContent “válido” para que .addProviderHistory / HistoryManager
+         * y otros accesos a sesión no fallen durante la generación.
+         */
+        private static JXMLContent createContentWithOwnerContext(JBaseWin owner, JWebRequest req) throws Exception {
+            JXMLContent z = createJXMLContentWithSessionContext(req);
+            try {
+                java.lang.reflect.Method setOwner = z.getClass().getMethod("setOwner", JBaseWin.class);
+                setOwner.invoke(z, owner);
+            } catch (NoSuchMethodException ignore) {
+            }
+            return z;
+        }
+
+        /**
+         * Crea un JXMLContent “válido” para que .addProviderHistory / HistoryManager
+         * y otros accesos a sesión no fallen durante la generación.
+         */
+        private static JXMLContent createJXMLContentWithSessionContext(JWebRequest req) throws Exception {
+            // Si tu proyecto tiene una factoría/constructor específico, usalo acá.
+            // Muchas bases tienen JXMLContent(JWebRequest) o con un “generator ctx”.
+            try {
 	        // Opción 1: constructor JXMLContent(JWebRequest)
 	        java.lang.reflect.Constructor<JXMLContent> c1 =
 	                JXMLContent.class.getConstructor(JWebRequest.class);


### PR DESCRIPTION
## Summary
- build reports in-process with new buildHtmlForOwner and buildXmlForOwner
- propagate owner context into in-memory XML generation
- render owner HTML via InternalReportService in JBaseWin

## Testing
- `javac -cp src -sourcepath src src/pss/www/platform/content/generators/internal/InternalReportService.java src/pss/core/win/JBaseWin.java` *(fails: unmappable characters and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d24b245c8333b4b12cb5d28022e5